### PR TITLE
Fix sonar warnings

### DIFF
--- a/Px.Utils.TestingApp/Commands/Benchmark.cs
+++ b/Px.Utils.TestingApp/Commands/Benchmark.cs
@@ -16,26 +16,28 @@ namespace Px.Utils.TestingApp.Commands
             internal readonly string Name;
             internal bool Error { get; }
             internal IReadOnlyList<double> IterationTimesMs { get; }
-            internal double MinTimeMs => Math.Round(IterationTimesMs.Min(), 2);
-            internal double MaxTimeMs => Math.Round(IterationTimesMs.Max(), 2);
-            internal double MeanTimeMs => Math.Round(IterationTimesMs.Average(), 2);
+            internal double MinTimeMs => Math.Round(IterationTimesMs.Min(), decimalPlaces);
+            internal double MaxTimeMs => Math.Round(IterationTimesMs.Max(), decimalPlaces);
+            internal double MeanTimeMs => Math.Round(IterationTimesMs.Average(), decimalPlaces);
             internal double MedianTimeMs
             {
                 get
                 {
                     List<double> sortedTimes = [.. IterationTimesMs.OrderBy(x => x)];
-                    return Math.Round(sortedTimes[sortedTimes.Count / 2], 2);
+                    return Math.Round(sortedTimes[sortedTimes.Count / decimalPlaces], decimalPlaces);
                 }
             }
-
+            
             internal double StandardDeviation
             {
                 get
                 {
                     double sumOfSquaresOfDifferences = IterationTimesMs.Select(val => (val - MeanTimeMs) * (val - MeanTimeMs)).Sum();
-                    return Math.Round(Math.Sqrt(sumOfSquaresOfDifferences / IterationTimesMs.Count), 2);
+                    return Math.Round(Math.Sqrt(sumOfSquaresOfDifferences / IterationTimesMs.Count), decimalPlaces);
                 }
             }
+
+            private const int decimalPlaces = 2;
 
             internal BenchmarkResult(string name, IReadOnlyList<double> iterationTimesMs)
             {
@@ -81,18 +83,20 @@ namespace Px.Utils.TestingApp.Commands
 
         internal List<BenchmarkResult> Results { get; } = [];
         private int processesCompleted = 0;
+        private const int minResultsLongestNameLength = 4;
+        private const int resultsTableWidth = 79;
 
         internal void PrintResults()
         {
             int longestNameLength = Results.Max(x => x.Name.Length);
-            if (longestNameLength < 4) longestNameLength = 4;
+            if (longestNameLength < minResultsLongestNameLength) longestNameLength = minResultsLongestNameLength;
             string format = "| {0,-" + longestNameLength + "} | {1,12} | {2,12} | {3,12} | {4,12} | {5,12} |";
 
             Console.WriteLine($"Benchmark results for {Iterations} iterations:");
-            Console.WriteLine(new string('-', longestNameLength + 79));
+            Console.WriteLine(new string('-', longestNameLength + resultsTableWidth));
             Console.WriteLine(format, "Name", "Min (ms)", "Max (ms)", "Mean (ms)", "Median (ms)", "Std. dev.");
 
-            Console.WriteLine(new string('-', longestNameLength + 79));
+            Console.WriteLine(new string('-', longestNameLength + resultsTableWidth));
             foreach (BenchmarkResult result in Results)
             {
                 if(result.Error)
@@ -270,20 +274,21 @@ namespace Px.Utils.TestingApp.Commands
             processesCompleted += increment;
             if (processesCompleted > 1)
             {
+                Console.Write(new string(' ', Console.WindowWidth));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
-                Console.Write(new string(' ', Console.WindowWidth * 2)); // Clear the line
+                Console.Write(new string(' ', Console.WindowWidth));
                 Console.SetCursorPosition(0, Console.CursorTop - 1);
             }
             float progress = (float)processesCompleted / totalProcesses;
 
             // Progress bar
-            int progressBarLength = 100;
+            const int progressBarLength = 100;
             int progressBlocks = (int)(progress * progressBarLength);
             Console.Write(new string('█', progressBlocks));
             Console.Write(new string('░', progressBarLength - progressBlocks));
             Console.WriteLine();
-
-            Console.Write($"Progress: {Math.Round(progress * 100f)}% - {processesCompleted} operations completed out of total {totalProcesses}");
+            const float percentageMultiplier = 100f;
+            Console.Write($"Progress: {Math.Round(progress * percentageMultiplier)}% - {processesCompleted} operations completed out of total {totalProcesses}");
 
             if (processesCompleted == totalProcesses)
             {

--- a/Px.Utils.TestingApp/Commands/BenchmarkRunner.cs
+++ b/Px.Utils.TestingApp/Commands/BenchmarkRunner.cs
@@ -27,8 +27,8 @@
 
         internal override void Run(bool batchMode, List<string>? inputs = null)
         {
-            string q = "Enter the benchmark name and optional parameters:";
-            string followUp = "Valid benchmark name is required, please input the benchmark name:";
+            const string q = "Enter the benchmark name and optional parameters:";
+            const string followUp = "Valid benchmark name is required, please input the benchmark name:";
 
             if (inputs is null || inputs.Count == 0)
             {

--- a/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
@@ -29,10 +29,12 @@ namespace Px.Utils.TestingApp.Commands
 
         private static readonly string[] cellFlags = ["-c", "-cells"];
 
+        private const string metadataNotFoundMessage = "Metadata not found.";
+
         internal DataReadBenchmark()
         {
             BenchmarkFunctions = [RunReadDoubleDataValuesBenchmarks, RunReadDecimalDataValuesBenchmarks, RunReadUnsafeDoubleBenchmarks];
-            BenchmarkFunctionsAsync = [RunReadDoubleDataValuesAsyncBenchmarks, RunReadDecimalDataValuesAsyncBenchmarks, RunReadUnsafeDoubleAsyncBenchmarks];
+            BenchmarkFunctionsAsync = [RunReadDoubleDataValuesBenchmarksAsync, RunReadDecimalDataValuesBenchmarksAsync, RunReadUnsafeDoubleBenchmarksAsync];
             ParameterFlags.Add(cellFlags);
         }
 
@@ -51,7 +53,7 @@ namespace Px.Utils.TestingApp.Commands
 
         private void RunReadDoubleDataValuesBenchmarks()
         {
-            if(MetaData is null) throw new InvalidOperationException("Metadata not found.");
+            if(MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Indexer = GenerateBenchmarkIndexer(MetaData, _numberOfCells);
 
             DoubleDataValue[] buffer = new DoubleDataValue[Indexer.DataLength];
@@ -64,7 +66,7 @@ namespace Px.Utils.TestingApp.Commands
 
         private void RunReadDecimalDataValuesBenchmarks()
         {
-            if (MetaData is null) throw new InvalidOperationException("Metadata not found.");
+            if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Indexer = GenerateBenchmarkIndexer(MetaData, _numberOfCells);
 
             DecimalDataValue[] buffer = new DecimalDataValue[Indexer.DataLength];
@@ -77,7 +79,7 @@ namespace Px.Utils.TestingApp.Commands
 
         private void RunReadUnsafeDoubleBenchmarks()
         {
-            if (MetaData is null) throw new InvalidOperationException("Metadata not found.");
+            if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Indexer = GenerateBenchmarkIndexer(MetaData, _numberOfCells);
 
             double[] buffer = new double[Indexer.DataLength];
@@ -89,9 +91,9 @@ namespace Px.Utils.TestingApp.Commands
             reader.ReadUnsafeDoubles(buffer, 0, Indexer, missingValueEncodings);
         }
 
-        private async Task RunReadDoubleDataValuesAsyncBenchmarks()
+        private async Task RunReadDoubleDataValuesBenchmarksAsync()
         {
-            if (MetaData is null) throw new InvalidOperationException("Metadata not found.");
+            if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Indexer = GenerateBenchmarkIndexer(MetaData, _numberOfCells);
 
             DoubleDataValue[] buffer = new DoubleDataValue[Indexer.DataLength];
@@ -102,9 +104,9 @@ namespace Px.Utils.TestingApp.Commands
             await reader.ReadDoubleDataValuesAsync(buffer, 0, Indexer);
         }
 
-        private async Task RunReadDecimalDataValuesAsyncBenchmarks()
+        private async Task RunReadDecimalDataValuesBenchmarksAsync()
         {
-            if (MetaData is null) throw new InvalidOperationException("Metadata not found.");
+            if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Indexer = GenerateBenchmarkIndexer(MetaData, _numberOfCells);
 
             DecimalDataValue[] buffer = new DecimalDataValue[Indexer.DataLength];
@@ -115,9 +117,9 @@ namespace Px.Utils.TestingApp.Commands
             await reader.ReadDecimalDataValuesAsync(buffer, 0, Indexer);
         }
 
-        private async Task RunReadUnsafeDoubleAsyncBenchmarks()
+        private async Task RunReadUnsafeDoubleBenchmarksAsync()
         {
-            if (MetaData is null) throw new InvalidOperationException("Metadata not found.");
+            if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Indexer = GenerateBenchmarkIndexer(MetaData, _numberOfCells);
 
             double[] buffer = new double[Indexer.DataLength];

--- a/Px.Utils.TestingApp/Commands/MetadataContentValidationBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/MetadataContentValidationBenchmark.cs
@@ -20,6 +20,8 @@ namespace Px.Utils.TestingApp.Commands
         {             
             BenchmarkFunctions = [ValidateContentBenchmark];
             BenchmarkFunctionsAsync = [ValidateContentAsyncBenchmark];
+            entries = [];
+            validator = new("", Encoding.Default);
         }
 
         protected override void OneTimeBenchmarkSetup()

--- a/Px.Utils.TestingApp/Commands/MetadataContentValidationBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/MetadataContentValidationBenchmark.cs
@@ -19,7 +19,7 @@ namespace Px.Utils.TestingApp.Commands
         internal MetadataContentValidationBenchmark()
         {             
             BenchmarkFunctions = [ValidateContentBenchmark];
-            BenchmarkFunctionsAsync = [ValidateContentAsyncBenchmark];
+            BenchmarkFunctionsAsync = [ValidateContentBenchmarkAsync];
             entries = [];
             validator = new("", Encoding.Default);
         }
@@ -31,7 +31,7 @@ namespace Px.Utils.TestingApp.Commands
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             Encoding encoding = PxFileMetadataReader.GetEncoding(stream);
             stream.Seek(0, SeekOrigin.Begin);
-            entries = SyntaxValidation.ValidatePxFileMetadataSyntax(stream, encoding, TestFilePath).Result.ToArray();
+            entries = [.. SyntaxValidation.ValidatePxFileMetadataSyntax(stream, encoding, TestFilePath).Result];
 
             validator = new(TestFilePath, encoding);
         }
@@ -41,7 +41,7 @@ namespace Px.Utils.TestingApp.Commands
             validator.Validate(entries);
         }
 
-        private async Task ValidateContentAsyncBenchmark()
+        private async Task ValidateContentBenchmarkAsync()
         {
             await validator.ValidateAsync(entries);
         }

--- a/Px.Utils.TestingApp/Commands/MetadataSyntaxValidationBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/MetadataSyntaxValidationBenchmark.cs
@@ -1,6 +1,5 @@
 ﻿using PxUtils.PxFile.Metadata;
 using PxUtils.Validation.SyntaxValidation;
-using System.ComponentModel.DataAnnotations;
 using System.Text;
 
 namespace Px.Utils.TestingApp.Commands
@@ -20,6 +19,7 @@ namespace Px.Utils.TestingApp.Commands
         {             
             BenchmarkFunctions = [SyntaxValidationBenchmark];
             BenchmarkFunctionsAsync = [SyntaxValidationAsyncBenchmark];
+            encoding = Encoding.Default;
         }
 
         protected override void OneTimeBenchmarkSetup()

--- a/Px.Utils.TestingApp/Commands/MetadataSyntaxValidationBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/MetadataSyntaxValidationBenchmark.cs
@@ -18,7 +18,7 @@ namespace Px.Utils.TestingApp.Commands
         internal MetadataSyntaxValidationBenchmark()
         {             
             BenchmarkFunctions = [SyntaxValidationBenchmark];
-            BenchmarkFunctionsAsync = [SyntaxValidationAsyncBenchmark];
+            BenchmarkFunctionsAsync = [SyntaxValidationBenchmarkAsync];
             encoding = Encoding.Default;
         }
 
@@ -39,7 +39,7 @@ namespace Px.Utils.TestingApp.Commands
             SyntaxValidation.ValidatePxFileMetadataSyntax(stream, encoding, TestFilePath);
         }
 
-        private async Task SyntaxValidationAsyncBenchmark()
+        private async Task SyntaxValidationBenchmarkAsync()
         {
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             stream.Seek(0, SeekOrigin.Begin);

--- a/Px.Utils.TestingApp/InteractiveFlow.cs
+++ b/Px.Utils.TestingApp/InteractiveFlow.cs
@@ -25,8 +25,8 @@ namespace PxUtils.TestingApp
         {
             while(true)
             {
-                string q = "Enter the command and optional parameters:";
-                string followUp = "Valid command is required, please input the command:";
+                const string q = "Enter the command and optional parameters:";
+                const string followUp = "Valid command is required, please input the command:";
                 List<string> inputs = TestAppConsole.AskQuestion(q, true, followUp);
                 while (!_commands.ContainsKey(inputs[0]))
                 {

--- a/Px.Utils/GlobalSuppressions.cs
+++ b/Px.Utils/GlobalSuppressions.cs
@@ -5,5 +5,13 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Major Bug", "S2583:Conditionally executed code should be reachable", Justification = "False positive", Scope = "member", Target = "~M:PxUtils.Models.Metadata.ExtensionMethods.PropertyExtensions.ParseStringList(System.String,System.Char,System.Char)~System.Collections.Generic.List{System.String}")]
-[assembly: SuppressMessage("Blocker Code Smell", "S2368:Public methods should not have multidimensional array parameters", Justification = "Index arithmetic is a key feature of this library", Scope = "member", Target = "~M:Px.Utils.PxFile.Data.DataIndexer.#ctor(System.Int32[][],System.Int32[])")]
+[assembly: SuppressMessage(
+    "Major Bug", "S2583:Conditionally executed code should be reachable", 
+    Justification = "False positive", 
+    Scope = "member", 
+    Target = "~M:PxUtils.Models.Metadata.ExtensionMethods.PropertyExtensions.ParseStringList(System.String,System.Char,System.Char)~System.Collections.Generic.List{System.String}")]
+[assembly: SuppressMessage(
+    "Blocker Code Smell", "S2368:Public methods should not have multidimensional array parameters", 
+    Justification = "Index arithmetic is a key feature of this library",
+    Scope = "member", 
+    Target = "~M:Px.Utils.PxFile.Data.DataIndexer.#ctor(System.Int32[][],System.Int32[])")]

--- a/Px.Utils/ModelBuilders/ValueParserUtilities.cs
+++ b/Px.Utils/ModelBuilders/ValueParserUtilities.cs
@@ -18,6 +18,7 @@ namespace PxUtils.ModelBuilders
         /// <returns>A <see cref="TimeDimensionInterval"/> enumeration value parsed from the input string.</returns>
         public static TimeDimensionInterval ParseTimeIntervalFromTimeVal(string input, PxFileSyntaxConf? conf = null)
         {
+            const int intervalStart = 6;
             conf ??= PxFileSyntaxConf.Default;
             string intervalPart = new(input.TakeWhile(c => c != conf.Symbols.Value.ListSeparator).ToArray());
             string inputStart = conf.Tokens.Time.TimeIntervalIndicator + conf.Symbols.Value.TimeSeriesIntervalStart;
@@ -33,7 +34,7 @@ namespace PxUtils.ModelBuilders
                     {conf.Tokens.Time.WeekInterval, TimeDimensionInterval.Week}
                 };
 
-                if(map.TryGetValue(intervalPart[6..^1], out TimeDimensionInterval interval)) return interval;
+                if(map.TryGetValue(intervalPart[intervalStart..^1], out TimeDimensionInterval interval)) return interval;
                 else return TimeDimensionInterval.Other;
             }
             else

--- a/Px.Utils/Models/Metadata/ExtensionMethods/PropertyExtensions.cs
+++ b/Px.Utils/Models/Metadata/ExtensionMethods/PropertyExtensions.cs
@@ -7,8 +7,10 @@ namespace PxUtils.Models.Metadata.ExtensionMethods
     {
         /// <summary>
         /// Extension method that returns the value of a <see cref="Property"/> object as a list of <see cref="MultilanguageString"/> objects, using the provided list separator and string delimiter.
-        /// This method checks if the input <see cref="Property"/> can get a multilanguage value. If it can, it parses each language string into a list of strings and constructs a list of <see cref="MultilanguageString"/> objects.
-        /// If the input <see cref="Property"/> cannot get a multilanguage value, it parses the string value of the <see cref="Property"/> into a list of strings and constructs a list of <see cref="MultilanguageString"/> objects with the backup language.
+        /// This method checks if the input <see cref="Property"/> can get a multilanguage value.
+        /// If it can, it parses each language string into a list of strings and constructs a list of <see cref="MultilanguageString"/> objects.
+        /// If the input <see cref="Property"/> cannot get a multilanguage value, it parses the string value of the <see cref="Property"/> into a list of strings 
+        /// and constructs a list of <see cref="MultilanguageString"/> objects with the backup language.
         /// </summary>
         /// <param name="input">The <see cref="Property"/> object to read the value from.</param>
         /// <param name="backupLang">The backup language to use if the <see cref="Property"/> cannot get a multilanguage value.</param>

--- a/Px.Utils/Models/Metadata/MatrixMetadata.cs
+++ b/Px.Utils/Models/Metadata/MatrixMetadata.cs
@@ -10,7 +10,11 @@ namespace PxUtils.Models.Metadata
     /// <param name="availableLanguages">Every available language for the matrix</param>
     /// <param name="dimensions">Ordered list of dimension objects that define the structure of the matrix</param>
     /// <param name="additionalProperties">Properties of the matrix object, excluding dimension metadata or the languages</param>
-    public class MatrixMetadata(string defaultLanguage, IReadOnlyList<string> availableLanguages, List<IDimension> dimensions, Dictionary<string, Property> additionalProperties) : IReadOnlyMatrixMetadata
+    public class MatrixMetadata(
+        string defaultLanguage,
+        IReadOnlyList<string> availableLanguages,
+        List<IDimension> dimensions,
+        Dictionary<string, Property> additionalProperties) : IReadOnlyMatrixMetadata
     {
         /// <summary>
         /// The default language of the matrix

--- a/Px.Utils/PxFile/CharacterConstants.cs
+++ b/Px.Utils/PxFile/CharacterConstants.cs
@@ -11,5 +11,9 @@
         public const char HORIZONTAL_TAB = (char)0x09;
         public const char CARRIAGE_RETURN = (char)0x0D;
         public const char LINE_FEED = (char)0x0A;
+
+        public readonly static byte[] BOM_UTF_8 = [0xEF, 0xBB, 0xBF];
+        public readonly static byte[] BOM_UTF_16 = [0xFE, 0xFF];
+        public readonly static byte[] BOM_UTF_32 = [0x00, 0x00, 0xFE];
     }
 }

--- a/Px.Utils/PxFile/Data/DataValueParsers.cs
+++ b/Px.Utils/PxFile/Data/DataValueParsers.cs
@@ -7,6 +7,11 @@ namespace PxUtils.PxFile.Data
 {
     public static class DataValueParsers
     {
+        const int decimalPlaceShift = 10;
+        const int stringDelimiterOffset = 2;
+        const int missingDataEntryMinLength = 3;
+        const int missingDataEntryMaxLength = 8;
+
         /// <summary>
         /// This method uses a fast, but potentially unsafe, parser to convert the characters into a <see cref="DoubleDataValue"/>.
         /// It is important that the input has been validated before using this method since the method does not perform any validation.
@@ -23,7 +28,7 @@ namespace PxUtils.PxFile.Data
             if (buffer[0] == '"')
             {
                 if (buffer[1] == '-') return new DoubleDataValue(0, DataValueType.Nill);
-                return new DoubleDataValue(0, (DataValueType)(len - 2));
+                return new DoubleDataValue(0, (DataValueType)(len - stringDelimiterOffset));
             }
             else
             {
@@ -48,7 +53,7 @@ namespace PxUtils.PxFile.Data
             if (buffer[0] == '"')
             {
                 if (buffer[1] == '-') return new DecimalDataValue(0, DataValueType.Nill);
-                return new DecimalDataValue(0, (DataValueType)(len - 2));
+                return new DecimalDataValue(0, (DataValueType)(len - stringDelimiterOffset));
             }
             else
             {
@@ -82,7 +87,7 @@ namespace PxUtils.PxFile.Data
             if (buffer[0] == '"')
             {
                 if (buffer[1] == '-') return missingValueEncodings[0];
-                return missingValueEncodings[len - 2];
+                return missingValueEncodings[len - stringDelimiterOffset];
             }
             else
             {
@@ -106,7 +111,7 @@ namespace PxUtils.PxFile.Data
             }
             else
             {
-                if (buffer[0] != '"' || buffer[len - 1] != '"' || len < 3 || len > 8)
+                if (buffer[0] != '"' || buffer[len - 1] != '"' || len < missingDataEntryMinLength || len > missingDataEntryMaxLength)
                 {
                     throw new ArgumentException($"Invalid symbol found when parsing data values {new string(buffer, 0, len)}");
                 }
@@ -114,7 +119,7 @@ namespace PxUtils.PxFile.Data
                 if (buffer[1] == '-') return new DoubleDataValue(0.0, DataValueType.Nill);
 
                 int dots = 0;
-                while (dots < len - 2)
+                while (dots < len - stringDelimiterOffset)
                 {
                     if (buffer[dots + 1] == '.') dots++;
                     else throw new ArgumentException($"Invalid symbol found when parsing data values {new string(buffer, 0, len)}");
@@ -140,7 +145,7 @@ namespace PxUtils.PxFile.Data
             }
             else
             {
-                if (buffer[0] != '"' || buffer[len - 1] != '"' || len < 3 || len > 8)
+                if (buffer[0] != '"' || buffer[len - 1] != '"' || len < missingDataEntryMinLength || len > missingDataEntryMaxLength)
                 {
                     throw new ArgumentException($"Invalid symbol found when parsing data values {new string(buffer, 0, len)}");
                 }
@@ -148,7 +153,7 @@ namespace PxUtils.PxFile.Data
                 if (buffer[1] == '-') return new DecimalDataValue(decimal.Zero, DataValueType.Nill);
 
                 int dots = 0;
-                while (dots < len - 2)
+                while (dots < len - stringDelimiterOffset)
                 {
                     if (buffer[dots + 1] == '.') dots++;
                     else throw new ArgumentException($"Invalid symbol found when parsing data values {new string(buffer, 0, len)}");
@@ -186,7 +191,7 @@ namespace PxUtils.PxFile.Data
             }
             else
             {
-                if (buffer[0] != '"' || buffer[len - 1] != '"' || len < 3 || len > 8)
+                if (buffer[0] != '"' || buffer[len - 1] != '"' || len < missingDataEntryMinLength || len > missingDataEntryMaxLength)
                 {
                     throw new ArgumentException($"Invalid symbol found when parsing data values {new string(buffer, 0, len)}");
                 }
@@ -194,7 +199,7 @@ namespace PxUtils.PxFile.Data
                 if (buffer[1] == '-') return missingValueEncodings[0];
 
                 int dots = 0;
-                while (dots < len - 2)
+                while (dots < len - stringDelimiterOffset)
                 {
                     if (buffer[dots + 1] == '.') dots++;
                     else throw new ArgumentException($"Invalid symbol found when parsing data values {new string(buffer, 0, len)}");
@@ -232,7 +237,7 @@ namespace PxUtils.PxFile.Data
                 char c = buffer[k];
                 if (c >= '0')
                 {
-                    n = (n * 10) + (c - '0');
+                    n = (n * decimalPlaceShift) + (c - '0');
                 }
                 else if (c == '.')
                 {
@@ -271,7 +276,7 @@ namespace PxUtils.PxFile.Data
                 char c = buffer[k];
                 if (c >= '0')
                 {
-                    n = (n * 10) + (c - '0');
+                    n = (n * decimalPlaceShift) + (c - '0');
                 }
                 else if (c == '.')
                 {

--- a/Px.Utils/PxFile/Data/PxFileStreamDataReader.cs
+++ b/Px.Utils/PxFile/Data/PxFileStreamDataReader.cs
@@ -14,6 +14,7 @@ namespace PxUtils.PxFile.Data
         private long readIndex = 0;
         private readonly int _readBufferSize;
         private readonly char _valueSeparator = ' ';
+        private const int validCharactersMinIndex = 0x21;
 
         #region Constructors
 
@@ -287,7 +288,7 @@ namespace PxUtils.PxFile.Data
                 for (int i = 0; i < read; i++) // Hot loop, mind the performance!
                 {
                     char c = (char)internalBuffer[i];
-                    if (c > 0x21)
+                    if (c > validCharactersMinIndex)
                     {
                         valueBuffer[valueBufferIndex++] = c;
                     }

--- a/Px.Utils/PxFile/Metadata/PxFileMetadataReader.cs
+++ b/Px.Utils/PxFile/Metadata/PxFileMetadataReader.cs
@@ -245,11 +245,12 @@ namespace PxUtils.PxFile.Metadata
         /// <returns>A Task that represents the asynchronous operation. The Task result contains the determined encoding of the stream.</returns>
         public static async Task<Encoding> GetEncodingAsync(Stream stream, PxFileSyntaxConf? symbolsConf = null, CancellationToken cancellationToken = default)
         {
+            const int bomLength = 3;
             symbolsConf ??= PxFileSyntaxConf.Default;
             long position = stream.Position;
 
-            byte[] bom = new byte[3];
-            await stream.ReadAsync(bom.AsMemory(0, 3), cancellationToken);
+            byte[] bom = new byte[bomLength];
+            await stream.ReadAsync(bom.AsMemory(0, bomLength), cancellationToken);
 
             stream.Position = position;
 
@@ -283,20 +284,15 @@ namespace PxUtils.PxFile.Metadata
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Encoding? GetBom(byte[] buffer)
         {
-            // UTF8 BOM
-            if (buffer[0] == 0xEF && buffer[1] == 0xBB && buffer[2] == 0xBF)
+            if (buffer.Take(CharacterConstants.BOM_UTF_8.Length).SequenceEqual(CharacterConstants.BOM_UTF_8))
             {
                 return Encoding.UTF8;
             }
-
-            // UTF16 BOM
-            else if (buffer[0] == 0xFE && buffer[1] == 0xFF)
+            else if (buffer.Take(CharacterConstants.BOM_UTF_16.Length).SequenceEqual(CharacterConstants.BOM_UTF_16))
             {
                 return Encoding.Unicode;
             }
-
-            // UTF32 BOM
-            else if (buffer[0] == 0x00 && buffer[1] == 0x00 && buffer[2] == 0xFE)
+            else if (buffer.Take(CharacterConstants.BOM_UTF_32.Length).SequenceEqual(CharacterConstants.BOM_UTF_32))
             {
                 return Encoding.UTF32;
             }

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.UtilityMethods.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.UtilityMethods.cs
@@ -80,8 +80,15 @@ namespace PxUtils.Validation.ContentValidation
         /// <param name="dimensionValueName">Name of the content dimension value requiring the entry</param>
         /// <param name="validator">Object that stores required information about the validation process</param>
         /// <param name="recommended">Optional that indicates if the keyword entry is recommended and should yield a warning if not found</param>
-        /// <returns>Returns a <see cref="ValidationFeedbackItem"/> object with an error if required entry is not found or with a warning if the entry specifiers are defined in an unexpected way</returns>
-        private static ValidationFeedbackItem? FindContentVariableKey(ValidationStructuredEntry[] entries, string keyword, KeyValuePair<string, string> languageAndDimensionPair, string dimensionValueName, ContentValidator validator, bool recommended = false)
+        /// <returns>Returns a <see cref="ValidationFeedbackItem"/> object with an error if required entry is not found 
+        /// or with a warning if the entry specifiers are defined in an unexpected way</returns>
+        private static ValidationFeedbackItem? FindContentVariableKey(
+            ValidationStructuredEntry[] entries, 
+            string keyword, 
+            KeyValuePair<string, string> languageAndDimensionPair, 
+            string dimensionValueName,
+            ContentValidator validator, 
+            bool recommended = false)
         {
             string language = languageAndDimensionPair.Key;
             string dimensionName = languageAndDimensionPair.Value;
@@ -141,7 +148,11 @@ namespace PxUtils.Validation.ContentValidation
         /// <param name="validator">Object that stores required information about the validation process</param>
         /// <param name="dimensionName">Name of the dimension</param>
         /// <returns>Returns a <see cref="ValidationFeedbackItem"/> object with a warning if the recommended entry is not found</returns>
-        private static ValidationFeedbackItem? FindDimensionRecommendedKey(ValidationStructuredEntry[] entries, string keyword, string language, ContentValidator validator, string? dimensionName = null)
+        private static ValidationFeedbackItem? FindDimensionRecommendedKey(
+            ValidationStructuredEntry[] entries, 
+            string keyword, string language, 
+            ContentValidator validator, 
+            string? dimensionName = null)
         {
             ValidationStructuredEntry[] keywordEntries = entries.Where(e => e.Key.Keyword.Equals(keyword)).ToArray();
             ValidationStructuredEntry? entry = Array.Find(keywordEntries,

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationFunctions.cs
@@ -94,7 +94,8 @@ namespace PxUtils.Validation.ContentValidation
         /// </summary>
         /// <param name="entries">Px file metadata entries in an array of <see cref="ValidationStructuredEntry"/> objects</param>
         /// <param name="validator"><see cref="ContentValidator"/> object that stores information that is gathered during the validation process</param>
-        /// <returns>Null if no issues are found. <see cref="ValidationFeedbackItem"/> object with a warning is returned if available languages entry is not found. Error is returned if multiple entries are found.</returns>
+        /// <returns>Null if no issues are found. <see cref="ValidationFeedbackItem"/> object with a warning is returned if available languages entry is not found. 
+        /// Error is returned if multiple entries are found.</returns>
         public static ValidationFeedbackItem[]? ValidateFindAvailableLanguages(ValidationStructuredEntry[] entries, ContentValidator validator)
         {
             ValidationStructuredEntry[] availableLanguageEntries = entries.Where(e => e.Key.Keyword.Equals(validator.SyntaxConf.Tokens.KeyWords.AvailableLanguages)).ToArray();
@@ -703,7 +704,8 @@ namespace PxUtils.Validation.ContentValidation
         }
 
         /// <summary>
-        /// Validates that specifiers are defined properly in the Px file metadata entry. Content dimension specifiers are allowed to be defined using only the first specifier at value level and are checked separately
+        /// Validates that specifiers are defined properly in the Px file metadata entry.
+        /// Content dimension specifiers are allowed to be defined using only the first specifier at value level and are checked separately
         /// </summary>
         /// <param name="entry">Entry in the Px file metadata. Represented by a <see cref="ValidationStructuredEntry"/> object</param>
         /// <param name="validator"><see cref="ContentValidator"/> object that stores information that is gathered during the validation process</param>

--- a/Px.Utils/Validation/ContentValidation/CustomContentValidationFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/CustomContentValidationFunctions.cs
@@ -3,8 +3,10 @@
     /// <summary>
     /// Object storing optional custom content validation functions
     /// </summary>
-    /// <param name="contentValidationSearchFunctions">Functions that are executed for the whole set of entries. This is used when specific entries are to be searched or stored during the validation. These are ran first in the validation process</param>
-    /// <param name="contentValidationEntryFunctions">Functions that are executed for individual entries. Used when specific properties of each or specific entries are to be validated. These functions are ran after the search functions in the validation process.</param>
+    /// <param name="contentValidationSearchFunctions">Functions that are executed for the whole set of entries. 
+    /// This is used when specific entries are to be searched or stored during the validation. These are ran first in the validation process</param>
+    /// <param name="contentValidationEntryFunctions">Functions that are executed for individual entries. Used when specific properties of each or specific entries are to be validated. 
+    /// These functions are ran after the search functions in the validation process.</param>
     public class CustomContentValidationFunctions(
         List<ContentValidationFindKeywordDelegate> contentValidationSearchFunctions,
         List<ContentValidationEntryDelegate> contentValidationEntryFunctions

--- a/Px.Utils/Validation/SyntaxValidation/SyntaxValidation.cs
+++ b/Px.Utils/Validation/SyntaxValidation/SyntaxValidation.cs
@@ -31,10 +31,13 @@ namespace PxUtils.Validation.SyntaxValidation
         /// <param name="stream">The stream of the PX file to be validated.</param>
         /// <param name="encoding">The encoding format to use for the PX file reading</param>
         /// <param name="filename">The name of the file to be validated.</param>
-        /// <param name="syntaxConf">An optional <see cref="PxFileSyntaxConf"/> parameter that specifies the syntax configuration for the PX file. If not provided, the default syntax configuration is used.</param>
+        /// <param name="syntaxConf">An optional <see cref="PxFileSyntaxConf"/> parameter that specifies the syntax configuration for the PX file. 
+        /// If not provided, the default syntax configuration is used.</param>
         /// <param name="bufferSize">An optional parameter that specifies the buffer size for reading the file. If not provided, a default buffer size of 4096 is used.</param>
-        /// <param name="customValidationFunctions">An optional <see cref="CustomValidationFunctions"/> parameter that specifies custom validation functions to be used during validation. If not provided, the default validation functions are used.</param>
-        /// <returns>A <see cref="SyntaxValidationResult"/> entry which contains a list of <see cref="ValidationStructuredEntry"/> entries and a list of <see cref="ValidationFeedbackItem"/> entries accumulated during the validation.</returns>
+        /// <param name="customValidationFunctions">An optional <see cref="CustomValidationFunctions"/> parameter that specifies custom validation functions to be used during validation. 
+        /// If not provided, the default validation functions are used.</param>
+        /// <returns>A <see cref="SyntaxValidationResult"/> entry which contains a list of <see cref="ValidationStructuredEntry"/> entries 
+        /// and a list of <see cref="ValidationFeedbackItem"/> entries accumulated during the validation.</returns>
         public static SyntaxValidationResult ValidatePxFileMetadataSyntax(
             Stream stream,
             Encoding encoding,
@@ -74,11 +77,14 @@ namespace PxUtils.Validation.SyntaxValidation
         /// <param name="stream">The stream of the PX file to be validated.</param>
         /// <param name="encoding">The encoding format to use for the PX file reading</param>
         /// <param name="filename">The name of the file to be validated.</param>
-        /// <param name="syntaxConf">An optional <see cref="PxFileSyntaxConf"/> parameter that specifies the syntax configuration for the PX file. If not provided, the default syntax configuration is used.</param>
+        /// <param name="syntaxConf">An optional <see cref="PxFileSyntaxConf"/> parameter that specifies the syntax configuration for the PX file. 
+        /// If not provided, the default syntax configuration is used.</param>
         /// <param name="bufferSize">An optional parameter that specifies the buffer size for reading the file. If not provided, a default buffer size of 4096 is used.</param>
-        /// <param name="customValidationFunctions">An optional <see cref="CustomValidationFunctions"/> parameter that specifies custom validation functions to be used during validation. If not provided, the default validation functions are used.</param>
+        /// <param name="customValidationFunctions">An optional <see cref="CustomValidationFunctions"/> parameter that specifies custom validation functions to be used during validation. 
+        /// If not provided, the default validation functions are used.</param>
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> parameter that can be used to cancel the operation.</param>
-        /// <returns>A task that contains a <see cref="SyntaxValidationResult"/> entry, which contains the structured validation entries and a list of <see cref="ValidationStructuredEntry"/> entries accumulated during the validation.</returns>
+        /// <returns>A task that contains a <see cref="SyntaxValidationResult"/> entry, which contains the structured validation entries 
+        /// and a list of <see cref="ValidationStructuredEntry"/> entries accumulated during the validation.</returns>
         public static async Task<SyntaxValidationResult> ValidatePxFileMetadataSyntaxAsync(
             Stream stream,
             Encoding encoding,
@@ -129,7 +135,10 @@ namespace PxUtils.Validation.SyntaxValidation
             return validationFeedback;
         }
 
-        private static List<ValidationFeedbackItem> ValidateKeyValuePairs(IEnumerable<ValidationKeyValuePair> kvpObjects, IEnumerable<KeyValuePairValidationFunctionDelegate> validationFunctions, PxFileSyntaxConf syntaxConf)
+        private static List<ValidationFeedbackItem> ValidateKeyValuePairs(
+            IEnumerable<ValidationKeyValuePair> kvpObjects,
+            IEnumerable<KeyValuePairValidationFunctionDelegate> validationFunctions,
+            PxFileSyntaxConf syntaxConf)
         {
             List<ValidationFeedbackItem> validationFeedback = [];
             foreach (ValidationKeyValuePair kvpObject in kvpObjects)
@@ -146,7 +155,10 @@ namespace PxUtils.Validation.SyntaxValidation
             return validationFeedback;
         }
 
-        private static List<ValidationFeedbackItem> ValidateStructs(IEnumerable<ValidationStructuredEntry> structuredEntries, IEnumerable<StructuredValidationFunctionDelegate> validationFunctions, PxFileSyntaxConf syntaxConf)
+        private static List<ValidationFeedbackItem> ValidateStructs(
+            IEnumerable<ValidationStructuredEntry> structuredEntries, 
+            IEnumerable<StructuredValidationFunctionDelegate> validationFunctions,
+            PxFileSyntaxConf syntaxConf)
         {
             List<ValidationFeedbackItem> validationFeedback = [];
             foreach (ValidationStructuredEntry structuredEntry in structuredEntries)
@@ -242,7 +254,13 @@ namespace PxUtils.Validation.SyntaxValidation
             return entryLineChangeIndexes;
         }
 
-        private static async Task<List<ValidationEntry>> BuildValidationEntriesAsync(Stream stream, Encoding encoding, PxFileSyntaxConf syntaxConf, string filename, int bufferSize, CancellationToken cancellationToken)
+        private static async Task<List<ValidationEntry>> BuildValidationEntriesAsync(
+            Stream stream, 
+            Encoding encoding,
+            PxFileSyntaxConf syntaxConf,
+            string filename,
+            int bufferSize,
+            CancellationToken cancellationToken)
         {
             bool isProcessingString = false;
             int characterIndex = 0;
@@ -313,9 +331,18 @@ namespace PxUtils.Validation.SyntaxValidation
 
         private static ValidationStructuredEntryKey ParseStructuredValidationEntryKey(string input, PxFileSyntaxConf syntaxConf)
         {
-            ExtractSectionResult languageResult = SyntaxValidationUtilityMethods.ExtractSectionFromString(input, syntaxConf.Symbols.Key.LangParamStart, syntaxConf.Symbols.Key.StringDelimeter, syntaxConf.Symbols.Key.LangParamEnd);
-            string? language = languageResult.Sections.Length > 0 ? SyntaxValidationUtilityMethods.CleanString(languageResult.Sections[0], syntaxConf).Trim(syntaxConf.Symbols.Key.StringDelimeter) : null;
-            ExtractSectionResult specifierResult = SyntaxValidationUtilityMethods.ExtractSectionFromString(languageResult.Remainder, syntaxConf.Symbols.Key.SpecifierParamStart, syntaxConf.Symbols.Key.StringDelimeter, syntaxConf.Symbols.Key.SpecifierParamEnd);
+            ExtractSectionResult languageResult = SyntaxValidationUtilityMethods.ExtractSectionFromString(
+                input, 
+                syntaxConf.Symbols.Key.LangParamStart, 
+                syntaxConf.Symbols.Key.StringDelimeter,
+                syntaxConf.Symbols.Key.LangParamEnd);
+            string? language = languageResult.Sections.Length > 0 ? 
+                SyntaxValidationUtilityMethods.CleanString(languageResult.Sections[0], syntaxConf).Trim(syntaxConf.Symbols.Key.StringDelimeter) :
+                null;
+            ExtractSectionResult specifierResult = SyntaxValidationUtilityMethods.ExtractSectionFromString(languageResult.Remainder,
+                syntaxConf.Symbols.Key.SpecifierParamStart, 
+                syntaxConf.Symbols.Key.StringDelimeter, 
+                syntaxConf.Symbols.Key.SpecifierParamEnd);
             string[] specifiers = specifierResult.Sections.Length > 0
                 ? SyntaxValidationUtilityMethods.ExtractSectionFromString(
                     specifierResult.Sections[0], 
@@ -323,8 +350,12 @@ namespace PxUtils.Validation.SyntaxValidation
                     syntaxConf.Symbols.Key.StringDelimeter)
                 .Sections 
                 : [];
-            string? firstSpecifier = specifiers.Length > 0 ? SyntaxValidationUtilityMethods.CleanString(specifiers[0], syntaxConf).Trim(syntaxConf.Symbols.Key.StringDelimeter) : null;
-            string? secondSpecifier = specifiers.Length > 1 ? SyntaxValidationUtilityMethods.CleanString(specifiers[1], syntaxConf).Trim(syntaxConf.Symbols.Key.StringDelimeter) : null;
+            string? firstSpecifier = specifiers.Length > 0 ?
+                SyntaxValidationUtilityMethods.CleanString(specifiers[0], syntaxConf).Trim(syntaxConf.Symbols.Key.StringDelimeter) : 
+                null;
+            string? secondSpecifier = specifiers.Length > 1 ?
+                SyntaxValidationUtilityMethods.CleanString(specifiers[1], syntaxConf).Trim(syntaxConf.Symbols.Key.StringDelimeter) :
+                null;
             string keyword = SyntaxValidationUtilityMethods.CleanString(specifierResult.Remainder, syntaxConf);
 
             return new(keyword, language, firstSpecifier, secondSpecifier);

--- a/Px.Utils/Validation/SyntaxValidation/SyntaxValidationFunctions.cs
+++ b/Px.Utils/Validation/SyntaxValidation/SyntaxValidationFunctions.cs
@@ -680,8 +680,9 @@ namespace PxUtils.Validation.SyntaxValidation
         {
             // We only need to run this validation if the value is less than 150 characters long and it is a string or list
             ValueType? type = SyntaxValidationUtilityMethods.GetValueTypeFromString(validationKeyValuePair.KeyValuePair.Value, syntaxConf);
-            
-            if (validationKeyValuePair.KeyValuePair.Value.Length > 150 ||
+            const int oneLineValueLengthRecommendedLimit = 150;
+
+            if (validationKeyValuePair.KeyValuePair.Value.Length > oneLineValueLengthRecommendedLimit ||
                 (type != ValueType.String &&
                 type != ValueType.ListOfStrings))
             {
@@ -1045,9 +1046,10 @@ namespace PxUtils.Validation.SyntaxValidation
         /// <returns>A <see cref="ValidationFeedbackItem"/> if the specifier is excessively long, otherwise null</returns>
         public static ValidationFeedbackItem? KeywordIsExcessivelyLong(ValidationStructuredEntry validationStructuredEntry, PxFileSyntaxConf syntaxConf)
         {
+            const int keywordLengthRecommendedLimit = 20;
             string keyword = validationStructuredEntry.Key.Keyword;
 
-            if (keyword.Length > 20)
+            if (keyword.Length > keywordLengthRecommendedLimit)
             {
                 KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
                     validationStructuredEntry.KeyStartLineIndex,

--- a/Px.Utils/Validation/SyntaxValidation/SyntaxValidationUtilityMethods.cs
+++ b/Px.Utils/Validation/SyntaxValidation/SyntaxValidationUtilityMethods.cs
@@ -30,7 +30,8 @@ namespace PxUtils.Validation.SyntaxValidation
     }
 
     /// <summary>
-    /// Provides a collection of helper methods used during the syntax validation process. These methods include functionality for extracting sections from a string, checking the format of a string, and determining the type of a value from a string.
+    /// Provides a collection of helper methods used during the syntax validation process. 
+    /// These methods include functionality for extracting sections from a string, checking the format of a string, and determining the type of a value from a string.
     /// </summary>
     public static class SyntaxValidationUtilityMethods
     {
@@ -43,7 +44,8 @@ namespace PxUtils.Validation.SyntaxValidation
         /// <param name="input">The input string to extract from</param>
         /// <param name="startSymbol">Symbol that starts enclosement</param>
         /// <param name="endSymbol">Optional symbol that closes the enclosement. If none given, startSymbol is used for both starting and ending the enclosement</param>
-        /// <return>Returns an <see cref="ExtractSectionResult"/> object that contains the extracted sections, the string that remains after the operation and starting indexes of extracted sections</return>
+        /// <return>Returns an <see cref="ExtractSectionResult"/> object that contains the extracted sections,
+        /// the string that remains after the operation and starting indexes of extracted sections</return>
         internal static ExtractSectionResult ExtractSectionFromString(string input, char startSymbol, char stringDelimeter, char? endSymbol = null)
         {
             // If no end symbol is provided, the start symbol is used for both starting and ending the enclosement
@@ -123,7 +125,8 @@ namespace PxUtils.Validation.SyntaxValidation
         /// <returns>Returns a boolean which is true if the input string is in a number format</returns>
         internal static bool IsNumberFormat(string input)
         {
-            if (input.Length > 29)
+            const int maxNumberLength = 29;
+            if (input.Length > maxNumberLength)
             {
                 return false;
             }
@@ -133,7 +136,7 @@ namespace PxUtils.Validation.SyntaxValidation
             }
 
             // Create a regex pattern to match valid number format
-            string pattern = @"^-?(\d+\.?\d*|\.\d+)$";
+            const string pattern = @"^-?(\d+\.?\d*|\.\d+)$";
 
             try
             {
@@ -150,7 +153,8 @@ namespace PxUtils.Validation.SyntaxValidation
         /// Determines whether the line changes in a string are compliant with the syntax configuration.
         /// </summary>
         /// <param name="input">The input string to check</param>
-        /// <param name="syntaxConf">Object that contains the symbols and tokens for structuring the file syntax. The syntax configuration is represented by a <see cref="PxFileSyntaxConf"/> object.</param>
+        /// <param name="syntaxConf">Object that contains the symbols and tokens for structuring the file syntax. 
+        /// The syntax configuration is represented by a <see cref="PxFileSyntaxConf"/> object.</param>
         /// <param name="isList">A boolean that is true if the input string is a list</param>
         /// <returns>Returns a boolean which is true if the line changes in the input string are compliant with the syntax configuration</returns>
         internal static bool ValueLineChangesAreCompliant(string input, PxFileSyntaxConf syntaxConf, bool isList)
@@ -173,7 +177,8 @@ namespace PxUtils.Validation.SyntaxValidation
         /// Determines the type of a value from a string.
         /// </summary>
         /// <param name="input">The input string to check</param>
-        /// <param name="syntaxConf">Object that contains the symbols and tokens for structuring the file syntax. The syntax configuration is represented by a <see cref="PxFileSyntaxConf"/> object.</param>
+        /// <param name="syntaxConf">Object that contains the symbols and tokens for structuring the file syntax.
+        /// The syntax configuration is represented by a <see cref="PxFileSyntaxConf"/> object.</param>
         /// <returns>Returns a <see cref="ValueType"/> object that represents the type of the value in the input string. If the type cannot be determined, null is returned.</returns>
         internal static ValueType? GetValueTypeFromString(string input, PxFileSyntaxConf syntaxConf)
         {
@@ -416,7 +421,11 @@ namespace PxUtils.Validation.SyntaxValidation
                 return false;
             }
 
-            ExtractSectionResult intervalSection = ExtractSectionFromString(input, syntaxConf.Symbols.Value.TimeSeriesIntervalStart, syntaxConf.Symbols.Key.StringDelimeter, syntaxConf.Symbols.Value.TimeSeriesIntervalEnd);
+            ExtractSectionResult intervalSection = ExtractSectionFromString(
+                input, 
+                syntaxConf.Symbols.Value.TimeSeriesIntervalStart, 
+                syntaxConf.Symbols.Key.StringDelimeter,
+                syntaxConf.Symbols.Value.TimeSeriesIntervalEnd);
             // There can only be one time interval specifier section
             if (intervalSection.Sections.Length != 1)
             {
@@ -539,7 +548,14 @@ namespace PxUtils.Validation.SyntaxValidation
             }
         }
 
-        private static void HandleStringDelimiter(ref bool insideString, ref bool insideSection, bool ignoreStringContents, StringBuilder sectionBuilder, List<string> sections, List<int> startIndexes, int i)
+        private static void HandleStringDelimiter(
+            ref bool insideString,
+            ref bool insideSection,
+            bool ignoreStringContents,
+            StringBuilder sectionBuilder,
+            List<string> sections, 
+            List<int> startIndexes, 
+            int i)
         {
             insideString = !insideString;
             if (!ignoreStringContents)

--- a/Px.Utils/Validation/SyntaxValidation/ValidationKeyValuePair.cs
+++ b/Px.Utils/Validation/SyntaxValidation/ValidationKeyValuePair.cs
@@ -12,7 +12,12 @@ namespace PxUtils.Validation.SyntaxValidation
     /// <param name="keyStartLineIndex">Index of the line where the entry starts.</param>
     /// <param name="lineChangeIndexes">Character indexes of the line changes in the entry starting from the entry start.</param>
     /// <param name="valueStartIndex">Index of the first character of the value in the entry.</param>
-    public class ValidationKeyValuePair(string file, KeyValuePair<string, string> keyValuePair, int keyStartLineIndex, int[] lineChangeIndexes, int valueStartIndex) : ValidationObject(file, keyStartLineIndex, lineChangeIndexes)
+    public class ValidationKeyValuePair(
+        string file,
+        KeyValuePair<string, string> keyValuePair,
+        int keyStartLineIndex,
+        int[] lineChangeIndexes, 
+        int valueStartIndex) : ValidationObject(file, keyStartLineIndex, lineChangeIndexes)
     {
         /// <summary>
         /// Contents of the entry, represented as a key-value pair.

--- a/Px.Utils/Validation/SyntaxValidation/ValidationStructuredEntry.cs
+++ b/Px.Utils/Validation/SyntaxValidation/ValidationStructuredEntry.cs
@@ -50,7 +50,14 @@
     /// <param name="keyStartLineIndex">Index of the line where the entry starts.</param>
     /// <param name="lineChangeIndexes">Character indexes of the line changes in the entry starting from the entry start.</param>
     /// <param name="valueStartIndex">Index of the first character of the value in the entry.</param>
-    public class ValidationStructuredEntry(string file, ValidationStructuredEntryKey key, string value, int keyStartLineIndex, int[] lineChangeIndexes, int valueStartIndex, ValueType? valueType) : ValidationObject(file, keyStartLineIndex, lineChangeIndexes)
+    public class ValidationStructuredEntry(
+        string file,
+        ValidationStructuredEntryKey key,
+        string value,
+        int keyStartLineIndex,
+        int[] lineChangeIndexes,
+        int valueStartIndex,
+        ValueType? valueType) : ValidationObject(file, keyStartLineIndex, lineChangeIndexes)
     {
         /// <summary>
         /// The key part of the entry, represented by a <see cref="ValidationStructuredEntryKey"/> object.


### PR DESCRIPTION
After reconfiguring rules for sonar, a bunch of new warnings and messages appeared. I went through them in this branch and fixed whatever was reasonably fixable. I didn't touch the cognitively complex functions of which there's two that still cause warnings in PxFileMetadataReader.

Most changes are either splitting excessively long lines or declaring constant variables to replace magic numbers.