### PR TITLE
Metadata helpers

### DIFF
--- a/Px.Utils.UnitTests/ModelTests/MatrixMetadataExtensionsTests.cs
+++ b/Px.Utils.UnitTests/ModelTests/MatrixMetadataExtensionsTests.cs
@@ -1,0 +1,39 @@
+﻿using Px.Utils.Models.Metadata;
+using Px.Utils.Models.Metadata.Dimensions;
+
+namespace Px.Utils.UnitTests.ModelTests
+{
+    [TestClass]
+    public class MatrixMetadataExtensionsTests
+    {
+        [TestMethod]
+        public void MatrixMetadataExtensionsGetContentDimensionReturnsContentDimension()
+        {
+            // Arrange
+            int[] dimensionSizes = [4, 3, 2, 1];
+            MatrixMetadata metadata = TestModelBuilder.BuildTestMetadata(dimensionSizes);
+
+            // Act
+            ContentDimension contentDimension = metadata.GetContentDimension();
+
+            // Assert
+            Assert.IsNotNull(contentDimension);
+            Assert.AreEqual(4, contentDimension.Values.Count);
+        }
+
+        [TestMethod]
+        public void MatrixMetadataExtensionsGetTimeDimensionReturnsTimeDimension()
+        {
+            // Arrange
+            int[] dimensionSizes = [4, 3, 2, 1];
+            MatrixMetadata metadata = TestModelBuilder.BuildTestMetadata(dimensionSizes);
+
+            // Act
+            TimeDimension timeDimension = metadata.GetTimeDimension();
+
+            // Assert
+            Assert.IsNotNull(timeDimension);
+            Assert.AreEqual(3, timeDimension.Values.Count);
+        }
+    }
+}

--- a/Px.Utils.UnitTests/ModelTests/ValueListTests.cs
+++ b/Px.Utils.UnitTests/ModelTests/ValueListTests.cs
@@ -1,0 +1,79 @@
+﻿using Px.Utils.Language;
+using Px.Utils.Models.Metadata.Dimensions;
+
+namespace Px.Utils.UnitTests.ModelTests
+{
+    [TestClass]
+    public class ValueListTests
+    {
+        [TestMethod]
+        public void ValueListMapReturnsPropertiesOfDimensionValues()
+        {
+            // Arrange
+            List<DimensionValue> values =
+            [
+                new ("1", new ("en", "foo"), true),
+                new ("2", new ("en", "bar"), false),
+            ];
+            ValueList valueList = new (values);
+
+            // Act
+            string[] codes = valueList.Map(v => v.Code).ToArray();
+            string[] names = valueList.Map(v => v.Name["en"]).ToArray();
+            bool[] isVirtual = valueList.Map(v => v.Virtual).ToArray();
+
+            // Assert
+            Assert.AreEqual(2, codes.Length);
+            Assert.AreEqual("1", codes[0]);
+            Assert.AreEqual("2", codes[1]);
+
+            Assert.AreEqual(2, names.Length);
+            Assert.AreEqual("foo", names[0]);
+            Assert.AreEqual("bar", names[1]);
+
+            Assert.AreEqual(2, isVirtual.Length);
+            Assert.IsTrue(isVirtual[0]);
+            Assert.IsFalse(isVirtual[1]);
+        }
+
+        [TestMethod]
+        public void ContentValueListMapReturnsPropertiesOfContentDimensionValues()
+        {
+            // Arrange
+            List<ContentDimensionValue> values =
+            [
+                new("1", new("en", "foo"), new("en", "kg"), DateTime.MinValue, 0),
+                new("2", new("en", "bar"), new("en", "m"), DateTime.MaxValue, 1)
+            ];
+            ContentValueList valueList = new(values);
+
+            // Act
+            string[] codes = valueList.Map(v => v.Code).ToArray();
+            string[] names = valueList.Map(v => v.Name["en"]).ToArray();
+            string[] units = valueList.Map(v => v.Unit["en"]).ToArray();
+            DateTime[] lastUpdated = valueList.Map(v => v.LastUpdated).ToArray();
+            int[] precisions = valueList.Map(v => v.Precision).ToArray();
+
+            // Assert
+            Assert.AreEqual(2, codes.Length);
+            Assert.AreEqual("1", codes[0]);
+            Assert.AreEqual("2", codes[1]);
+
+            Assert.AreEqual(2, names.Length);
+            Assert.AreEqual("foo", names[0]);
+            Assert.AreEqual("bar", names[1]);
+
+            Assert.AreEqual(2, units.Length);
+            Assert.AreEqual("kg", units[0]);
+            Assert.AreEqual("m", units[1]);
+
+            Assert.AreEqual(2, lastUpdated.Length);
+            Assert.AreEqual(DateTime.MinValue, lastUpdated[0]);
+            Assert.AreEqual(DateTime.MaxValue, lastUpdated[1]);
+
+            Assert.AreEqual(2, precisions.Length);
+            Assert.AreEqual(0, precisions[0]);
+            Assert.AreEqual(1, precisions[1]);
+        }
+    }
+}

--- a/Px.Utils/Models/Metadata/Dimensions/ValueList.cs
+++ b/Px.Utils/Models/Metadata/Dimensions/ValueList.cs
@@ -70,15 +70,15 @@ namespace Px.Utils.Models.Metadata.Dimensions
         }
 
         /// <summary>
-        /// Returns an enurable collection of requested properties of the value list that matches the selector function.
+        /// Transforms the dimension values to an enumerable collection of the specified type.
         /// </summary>
-        /// <param name="selector">Condition to check the value against.</param>
-        /// <returns>Enumerable collection of the requested type in which all items match the condition</returns>
-        public virtual IEnumerable<TResult> Map<TResult>(Func<DimensionValue, TResult> selector)
+        /// <param name="func">Condition to check the value against.</param>
+        /// <returns>Collection of the specified type.</returns>
+        public virtual IEnumerable<TResult> Map<TResult>(Func<DimensionValue, TResult> func)
         {
-            foreach (DimensionValue dimension in Values)
+            foreach (DimensionValue dimension in this)
             {
-                yield return selector(dimension);
+                yield return func(dimension);
             }
         }
 
@@ -167,15 +167,15 @@ namespace Px.Utils.Models.Metadata.Dimensions
             => Values.Cast<ContentDimensionValue>().GetEnumerator();
 
         /// <summary>
-        /// Returns an enurable collection of requested properties of the value list that matches the selector function.
+        /// Transforms the content dimension values to a enumerable collection of the specified type.
         /// </summary>
-        /// <param name="selector">Condition to check the value against.</param>
-        /// <returns>Enumerable collection of the requested type in which all items match the condition</returns>
-        public IEnumerable<TResult> Map<TResult>(Func<ContentDimensionValue, TResult> selector)
+        /// <param name="func">Condition to check the value against.</param>
+        /// <returns>Collection of the specified type.</returns>
+        public IEnumerable<TResult> Map<TResult>(Func<ContentDimensionValue, TResult> func)
         {
-            foreach (ContentDimensionValue dimension in Values.Cast<ContentDimensionValue>())
+            foreach (ContentDimensionValue dimension in this)
             {
-                yield return selector(dimension);
+                yield return func(dimension);
             }
         }
     }

--- a/Px.Utils/Models/Metadata/Dimensions/ValueList.cs
+++ b/Px.Utils/Models/Metadata/Dimensions/ValueList.cs
@@ -1,5 +1,4 @@
-﻿using Px.Utils.Models.Metadata.Dimensions;
-using System.Collections;
+﻿using System.Collections;
 
 namespace Px.Utils.Models.Metadata.Dimensions
 {
@@ -68,6 +67,19 @@ namespace Px.Utils.Models.Metadata.Dimensions
                 }
             }
             return null;
+        }
+
+        /// <summary>
+        /// Returns an enurable collection of requested properties of the value list that matches the selector function.
+        /// </summary>
+        /// <param name="selector">Condition to check the value against.</param>
+        /// <returns>Enumerable collection of the requested type in which all items match the condition</returns>
+        public virtual IEnumerable<TResult> Map<TResult>(Func<DimensionValue, TResult> selector)
+        {
+            foreach (DimensionValue dimension in Values)
+            {
+                yield return selector(dimension);
+            }
         }
 
         /// <summary>
@@ -153,5 +165,18 @@ namespace Px.Utils.Models.Metadata.Dimensions
         /// <returns>An enumerator that can be used to iterate through the content dimension values.</returns>
         public override IEnumerator<ContentDimensionValue> GetEnumerator()
             => Values.Cast<ContentDimensionValue>().GetEnumerator();
+
+        /// <summary>
+        /// Returns an enurable collection of requested properties of the value list that matches the selector function.
+        /// </summary>
+        /// <param name="selector">Condition to check the value against.</param>
+        /// <returns>Enumerable collection of the requested type in which all items match the condition</returns>
+        public IEnumerable<TResult> Map<TResult>(Func<ContentDimensionValue, TResult> selector)
+        {
+            foreach (ContentDimensionValue dimension in Values.Cast<ContentDimensionValue>())
+            {
+                yield return selector(dimension);
+            }
+        }
     }
 }

--- a/Px.Utils/Models/Metadata/Dimensions/ValueList.cs
+++ b/Px.Utils/Models/Metadata/Dimensions/ValueList.cs
@@ -72,8 +72,8 @@ namespace Px.Utils.Models.Metadata.Dimensions
         /// <summary>
         /// Transforms the dimension values to an enumerable collection of the specified type.
         /// </summary>
-        /// <param name="func">Condition to check the value against.</param>
-        /// <returns>Collection of the specified type.</returns>
+        /// <param name="func">Function to transform the dimension values.</param>
+        /// <returns>Enumerable of the specified type.</returns>
         public virtual IEnumerable<TResult> Map<TResult>(Func<DimensionValue, TResult> func)
         {
             foreach (DimensionValue dimension in this)
@@ -169,8 +169,8 @@ namespace Px.Utils.Models.Metadata.Dimensions
         /// <summary>
         /// Transforms the content dimension values to a enumerable collection of the specified type.
         /// </summary>
-        /// <param name="func">Condition to check the value against.</param>
-        /// <returns>Collection of the specified type.</returns>
+        /// <param name="func">Function to transform the content dimension values.</param>
+        /// <returns>Enumerable collection of the specified type.</returns>
         public IEnumerable<TResult> Map<TResult>(Func<ContentDimensionValue, TResult> func)
         {
             foreach (ContentDimensionValue dimension in this)

--- a/Px.Utils/Models/Metadata/MatrixMetadataExtensions.cs
+++ b/Px.Utils/Models/Metadata/MatrixMetadataExtensions.cs
@@ -6,14 +6,14 @@ namespace Px.Utils.Models.Metadata
     {
         public static ContentDimension GetContentDimension(this MatrixMetadata metadata)
         {
-            ContentDimension? ct = metadata.Dimensions.OfType<ContentDimension>().FirstOrDefault();
-            return ct ?? throw new InvalidOperationException("Content dimension not found in metadata");
+            ContentDimension? contentDimension = metadata.Dimensions.Find(dimension => dimension.Type == Enums.DimensionType.Content) as ContentDimension;
+            return contentDimension ?? throw new InvalidOperationException("Content dimension not found in metadata");
         }
 
         public static TimeDimension GetTimeDimension(this MatrixMetadata metadata)
-        {             
-            TimeDimension? time = metadata.Dimensions.OfType<TimeDimension>().FirstOrDefault();
-            return time ?? throw new InvalidOperationException("Time dimension not found in metadata");
+        {
+            TimeDimension? timeDimension = metadata.Dimensions.Find(dimension => dimension.Type == Enums.DimensionType.Time) as TimeDimension;
+            return timeDimension ?? throw new InvalidOperationException("Time dimension not found in metadata");
         }
     }
 }

--- a/Px.Utils/Models/Metadata/MatrixMetadataExtensions.cs
+++ b/Px.Utils/Models/Metadata/MatrixMetadataExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Px.Utils.Models.Metadata.Dimensions;
+
+namespace Px.Utils.Models.Metadata
+{
+    public static class MatrixMetadataExtensions
+    {
+        public static ContentDimension GetContentDimension(this MatrixMetadata metadata)
+        {
+            ContentDimension? ct = metadata.Dimensions.OfType<ContentDimension>().FirstOrDefault();
+            return ct ?? throw new InvalidOperationException("Content dimension not found in metadata");
+        }
+
+        public static TimeDimension GetTimeDimension(this MatrixMetadata metadata)
+        {             
+            TimeDimension? time = metadata.Dimensions.OfType<TimeDimension>().FirstOrDefault();
+            return time ?? throw new InvalidOperationException("Time dimension not found in metadata");
+        }
+    }
+}

--- a/Px.Utils/Px.Utils.csproj
+++ b/Px.Utils/Px.Utils.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<PackageId>Px.Utils</PackageId>
-	<Version>1.0.2</Version>
+	<Version>1.0.3</Version>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
- ValueList and ContentValueList now include Map method that mimics the functionality of LINQ.Select
- MatrixMetadataExtensions class that contains functions for finding ContentDimension and TimeDimension from MatrixMetadata

Tests