### PR TITLE
Datareader errorhandling improvements

### DIFF
--- a/Px.Utils.UnitTests/ModelBuilderTests/MatrixMetadataBuilderTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/MatrixMetadataBuilderTests.cs
@@ -8,10 +8,8 @@ using Px.Utils.Models.Metadata.MetaProperties;
 using Px.Utils.PxFile;
 using Px.Utils.UnitTests.ModelBuilderTests.Fixtures;
 using System.Globalization;
-using Px.Utils.PxFile;
-using Px.Utils.UnitTests.ModelBuilderTests.Fixtures;
 
-namespace ModelBuilderTests
+namespace Px.Utils.UnitTests.ModelBuilderTests
 {
     [TestClass]
     public class MatrixMetadataBuilderTests
@@ -19,7 +17,7 @@ namespace ModelBuilderTests
         private MatrixMetadata Actual_3Lang { get; } = new MatrixMetadataBuilder().Build(PxFileMetaEntries_Robust_3_Languages.Entries);
         private MatrixMetadata Actual_1Lang { get; } = new MatrixMetadataBuilder().Build(PxFileMetaEntries_Robust_1_Language.Entries);
         private MatrixMetadata Actual_Recommended_3Lang { get; } = new MatrixMetadataBuilder().Build(PxFileMetaEntries_Recommended_3_Langs.Entries);
-        private MatrixMetadata Actual_1Lang_With_Table_Level_Units_And_Precision { get; } = 
+        private MatrixMetadata Actual_1Lang_With_Table_Level_Units_And_Precision { get; } =
             new MatrixMetadataBuilder().Build(PxFileMetaEntries_Robust_1_Language_With_Table_Level_Units_And_Precision.Entries);
 
         [TestMethod]
@@ -29,7 +27,7 @@ namespace ModelBuilderTests
             MatrixMetadata meta = builder.Build(PxFileMetaEntries_Robust_3_Languages.Entries);
             Assert.IsNotNull(meta);
         }
-        
+
         [TestMethod]
         public void DictionaryBuildTest()
         {
@@ -70,7 +68,7 @@ namespace ModelBuilderTests
         [DataRow("20240131 08:00", "NEXT-UPDATE")]
         public void MultiLangTableLevelAdditionalNotTranslatedStringParametersTest(string expected, string keyWord)
         {
-            if(Actual_3Lang.AdditionalProperties[keyWord] is StringProperty asp)
+            if (Actual_3Lang.AdditionalProperties[keyWord] is StringProperty asp)
             {
                 Assert.AreEqual(expected, asp.Value);
             }
@@ -84,7 +82,7 @@ namespace ModelBuilderTests
         [DataRow(true, "OFFICIAL-STATISTICS")]
         public void MultiLangTableLevelAdditionalBoolParametersTest(bool expected, string keyWord)
         {
-            if(Actual_3Lang.AdditionalProperties[keyWord] is BooleanProperty abp)
+            if (Actual_3Lang.AdditionalProperties[keyWord] is BooleanProperty abp)
             {
                 Assert.AreEqual(expected, abp.Value);
             }
@@ -102,7 +100,7 @@ namespace ModelBuilderTests
         [DataRow("20240131 08:00", "NEXT-UPDATE")]
         public void SingleLangTableLevelAdditionalNotTranslatedParametersTest(string expected, string keyWord)
         {
-            if(Actual_1Lang.AdditionalProperties[keyWord] is StringProperty asp)
+            if (Actual_1Lang.AdditionalProperties[keyWord] is StringProperty asp)
             {
                 Assert.AreEqual(expected, asp.Value);
             }
@@ -116,7 +114,7 @@ namespace ModelBuilderTests
         [DataRow(true, "OFFICIAL-STATISTICS")]
         public void SingleLangTableLevelAdditionalNotTranslatedParametersTest(bool expected, string keyWord)
         {
-            if(Actual_1Lang.AdditionalProperties[keyWord] is BooleanProperty abp)
+            if (Actual_1Lang.AdditionalProperties[keyWord] is BooleanProperty abp)
             {
                 Assert.AreEqual(expected, abp.Value);
             }
@@ -149,7 +147,7 @@ namespace ModelBuilderTests
         [DataRow("test_note_fi", "NOTE")]
         public void SingleLangTableLevelAdditionalTranslatedParametersTest(string input, string keyWord)
         {
-            if(Actual_1Lang.AdditionalProperties[keyWord] is StringProperty msp)
+            if (Actual_1Lang.AdditionalProperties[keyWord] is StringProperty msp)
             {
                 Assert.AreEqual(input, msp.Value);
             }
@@ -220,11 +218,11 @@ namespace ModelBuilderTests
                 new("fi", "%"),
                 new("fi", "lukumäärä")
             ];
-            for(int i = 0; i < contentDimension.Values.Count; i++)
+            for (int i = 0; i < contentDimension.Values.Count; i++)
             {
                 Assert.AreEqual(expectedUnits[i], contentDimension.Values[i].Unit);
             }
-            for(int i = 0; i < contentDimension.Values.Count; i++)
+            for (int i = 0; i < contentDimension.Values.Count; i++)
             {
                 Assert.AreEqual(1, contentDimension.Values[i].Precision);
             }
@@ -408,7 +406,7 @@ namespace ModelBuilderTests
         {
             Dimension? building_type_dim = Actual_3Lang.Dimensions.Find(d => d.Code == "Talotyyppi");
             Assert.IsNotNull(building_type_dim);
-            if(building_type_dim.AdditionalProperties["ELIMINATION"] is MultilanguageStringProperty msp)
+            if (building_type_dim.AdditionalProperties["ELIMINATION"] is MultilanguageStringProperty msp)
             {
                 MultilanguageString expected = new([new("fi", "Talotyypit yhteensä"), new("sv", "Hustyp totalt"), new("en", "Building types total")]);
                 Assert.AreEqual(expected, msp.Value);
@@ -424,7 +422,7 @@ namespace ModelBuilderTests
         {
             Dimension? building_type_dim = Actual_1Lang.Dimensions.Find(d => d.Code == "Talotyyppi");
             Assert.IsNotNull(building_type_dim);
-            if(building_type_dim.AdditionalProperties["ELIMINATION"] is StringProperty msp)
+            if (building_type_dim.AdditionalProperties["ELIMINATION"] is StringProperty msp)
             {
                 Assert.AreEqual("Talotyypit yhteensä", msp.Value);
             }

--- a/Px.Utils.UnitTests/ModelTests/ExtensionTests/MatrixMapExtensionTests.cs
+++ b/Px.Utils.UnitTests/ModelTests/ExtensionTests/MatrixMapExtensionTests.cs
@@ -1,0 +1,219 @@
+﻿using Px.Utils.Models.Metadata;
+using Px.Utils.Models.Metadata.ExtensionMethods;
+
+namespace Px.Utils.UnitTests.ModelTests.ExtensionTests
+{
+    [TestClass]
+    public class MatrixMapExtensionTests
+    {
+        [TestMethod]
+        public void WhenCalledWithItselfShouldReturnTrue()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert
+            Assert.IsTrue(map.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithSubmapShouldReturnTrue()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["aa11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33"]),
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsTrue(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithSubmapWithoutfirstValuesShouldReturnTrue()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["bb11", "cc11"]),
+                    new DimensionMap("22", ["bb22"]),
+                    new DimensionMap("33", ["bb33", "cc33", "dd33"]),
+
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsTrue(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithSizeOneSubmapShouldReturnTrue()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["cc11"]),
+                    new DimensionMap("22", ["bb22"]),
+                    new DimensionMap("33", ["cc33"]),
+
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsTrue(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithDifferentDimensionOrderShouldReturnFalse()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsFalse(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithDifferentValuesShouldReturnFalse()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33", "ee33"]),
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsFalse(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithDifferentNumberOfDimensionsShouldReturnFalse()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsFalse(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithDifferenValueOrderShouldReturnFalse()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "cc33", "bb33"]),
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsFalse(subMap.IsSubmapOf(map));
+        }
+
+        [TestMethod]
+        public void WhenCalledWithNotMatchingValueCodesShouldReturnFalse()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["aa22", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bb33", "cc33", "dd33"]),
+                ];
+
+            MatrixMap map = new(dimensions);
+
+            List<IDimensionMap> subDimensions = [
+                    new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                    new DimensionMap("22", ["foo", "bb22"]),
+                    new DimensionMap("33", ["aa33", "bar"]),
+                ];
+
+            MatrixMap subMap = new(subDimensions);
+
+            // Act and Assert
+            Assert.IsFalse(subMap.IsSubmapOf(map));
+        }
+
+    }
+}

--- a/Px.Utils.UnitTests/PxFileTests/DataTests/DataIndexerTests.cs
+++ b/Px.Utils.UnitTests/PxFileTests/DataTests/DataIndexerTests.cs
@@ -174,5 +174,32 @@ namespace PxFileTests.DataTests
             }
             while (generator.Next());
         }
+
+        [TestMethod]
+        public void MismatchingValueCodesShouldCauseArgumentException()
+        {
+            MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([3, 2, 5]);
+            MatrixMap matrixMap = new(
+            [
+                new DimensionMap("var0", ["var0_val2", "var0_val1"]),
+                new DimensionMap("var1", ["var2_val0", "var1_val1"]),
+                new DimensionMap("var2", ["var2_val4", "var2_val3"])
+            ]);
+
+            Assert.ThrowsException<ArgumentException>(() => new DataIndexer(testMeta, matrixMap));
+        }
+
+        [TestMethod]
+        public void MissingDimensionShouldCauseArgumentException()
+        {
+            MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([3, 2, 5]);
+            MatrixMap matrixMap = new(
+            [
+                new DimensionMap("var0", ["var0_val2", "var0_val1"]),
+                new DimensionMap("var1", ["var1_val0", "var1_val1"])
+            ]);
+
+            Assert.ThrowsException<ArgumentException>(() => new DataIndexer(testMeta, matrixMap));
+        }
     }
 }

--- a/Px.Utils.UnitTests/PxFileTests/DataTests/PxFileStreamDataReaderTests/AsyncDataReaderTests.cs
+++ b/Px.Utils.UnitTests/PxFileTests/DataTests/PxFileStreamDataReaderTests/AsyncDataReaderTests.cs
@@ -26,14 +26,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             double[] expexted =
             [
@@ -59,14 +58,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             double[] expexted =
             [
@@ -92,14 +90,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             DoubleDataValue[] expexted =
@@ -131,14 +128,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
-                new DimensionMap("var2", ["var1_val0"])
+                new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer, cToken);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta, cToken);
 
             double[] expexted = [0.00, 2.00, 4.00, 6.00, 8.00, canary];
             // The canary in the expected checks against overwrites
@@ -156,19 +152,18 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             DoubleDataValue[] targetBuffer = new DoubleDataValue[5];
 
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var1_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
 
             using CancellationTokenSource cts = new();
             await cts.CancelAsync();
             CancellationToken cToken = cts.Token;
 
-            async Task call() => await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer, cToken);
+            async Task call() => await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta, cToken);
             await Assert.ThrowsExceptionAsync<TaskCanceledException>(call);
         }
 
@@ -186,14 +181,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, indexer, cToken);
+            await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, targetMap, testMeta, cToken);
 
             decimal[] expexted =
             [
@@ -215,19 +209,18 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
 
             using CancellationTokenSource cts = new();
             await cts.CancelAsync();
             CancellationToken cToken = cts.Token;
 
-            async Task call() => await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, indexer, cToken);
+            async Task call() => await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, targetMap, testMeta, cToken);
             await Assert.ThrowsExceptionAsync<TaskCanceledException>(call);
         }
 
@@ -245,14 +238,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, indexer, missingMarkers, cToken);
+            await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, targetMap, testMeta, missingMarkers, cToken);
 
             double[] expexted =
             [
@@ -274,20 +266,19 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             double[] targetBuffer = new double[20];
 
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
 
             using CancellationTokenSource cts = new();
             await cts.CancelAsync();
             CancellationToken cToken = cts.Token;
 
             // Act and Assert
-            async Task call() => await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, indexer, missingMarkers, cToken);
+            async Task call() => await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, targetMap, testMeta, missingMarkers, cToken);
             await Assert.ThrowsExceptionAsync<TaskCanceledException>(call);
         }
 
@@ -304,14 +295,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
-                new DimensionMap("var2", ["var1_val0"])
+                new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
 
             double[] expexted = [0.00, 2.00, 4.00, 6.00, 8.00, canary];
@@ -332,14 +322,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
-                new DimensionMap("var2", ["var1_val0"])
+                new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [10.00, 12.00, 14.00, 16.00, 18.00];
@@ -357,14 +346,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted =
@@ -387,14 +375,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
-                new DimensionMap("var2", ["var1_val0"])
+                new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [0.00, 0.02, 0.04, 0.06, 0.08];
@@ -412,14 +399,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
-                new DimensionMap("var2", ["var1_val0"])
+                new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [0.10, 0.12, 0.14, 0.16, 0.18];
@@ -437,14 +423,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted =
@@ -467,14 +452,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             decimal[] expexted =
@@ -497,14 +481,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, indexer);
+            await reader.ReadDecimalDataValuesAsync(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             decimal[] expexted =
@@ -527,14 +510,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, indexer, missingMarkers);
+            await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, targetMap, testMeta, missingMarkers);
 
             // Assert
             double[] expexted =
@@ -557,14 +539,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0", "var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, indexer, missingMarkers);
+            await reader.ReadUnsafeDoublesAsync(targetBuffer, 0, targetMap, testMeta, missingMarkers);
 
             // Assert
             double[] expexted =
@@ -575,7 +556,5 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             CollectionAssert.AreEqual(expexted, targetBuffer);
         }
-
-
     }
 }

--- a/Px.Utils.UnitTests/PxFileTests/DataTests/PxFileStreamDataReaderTests/DataReaderTests.cs
+++ b/Px.Utils.UnitTests/PxFileTests/DataTests/PxFileStreamDataReaderTests/DataReaderTests.cs
@@ -32,8 +32,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             double[] expexted =
@@ -65,8 +64,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             double[] expexted =
@@ -98,8 +96,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             DoubleDataValue[] expexted =
@@ -128,14 +125,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [0.00, 2.00, 4.00, 6.00, 8.00, canary];
@@ -155,14 +151,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [10.00, 12.00, 14.00, 16.00, 18.00];
@@ -186,8 +181,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             double[] expexted =
@@ -210,14 +204,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [0.00, 0.02, 0.04, 0.06, 0.08];
@@ -235,14 +228,13 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
 
             // Act
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 5, 2]);
-            MatrixMap matrixMap = new(
+            MatrixMap targetMap = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap, testMeta);
 
             // Assert
             double[] expexted = [0.10, 0.12, 0.14, 0.16, 0.18];
@@ -266,8 +258,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer);
+            reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             double[] expexted =
@@ -296,8 +287,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDecimalDataValues(targetBuffer, 0, indexer);
+            reader.ReadDecimalDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             decimal[] expexted =
@@ -326,8 +316,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadDecimalDataValues(targetBuffer, 0, indexer);
+            reader.ReadDecimalDataValues(targetBuffer, 0, testMeta, matrixMap);
 
             // Assert
             decimal[] expexted =
@@ -356,8 +345,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadUnsafeDoubles(targetBuffer, 0, indexer, missingMarkers);
+            reader.ReadUnsafeDoubles(targetBuffer, 0, testMeta, matrixMap, missingMarkers);
 
             // Assert
             double[] expexted =
@@ -386,8 +374,7 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val0", "var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer = new(testMeta, matrixMap);
-            reader.ReadUnsafeDoubles(targetBuffer, 0, indexer, missingMarkers);
+            reader.ReadUnsafeDoubles(targetBuffer, 0, testMeta, matrixMap, missingMarkers);
 
             // Assert
             double[] expexted =
@@ -397,6 +384,50 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             ];
 
             CollectionAssert.AreEqual(expexted, targetBuffer);
+        }
+
+        [TestMethod]
+        public void ReadDoubleDataValuesInWrongOrderThrowsArgumentException()
+        {
+            // Arrange
+            byte[] data = Encoding.UTF8.GetBytes(DataReaderFixtures.MINIMAL_UTF8_20DATAVALUES);
+            using Stream stream = new MemoryStream(data);
+            using PxFileStreamDataReader reader = new(stream);
+            DoubleDataValue[] targetBuffer = new DoubleDataValue[20];
+
+            // Act
+            MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
+            MatrixMap matrixMap = new(
+            [
+                new DimensionMap("var0", ["var0_val1", "var0_val0"]),
+                new DimensionMap("var1", ["var1_val0", "var1_val1"]),
+                new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
+            ]);
+
+            // Assert
+            Assert.ThrowsException<ArgumentException>(() => reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap));
+        }
+
+        [TestMethod]
+        public void ReadDoubleDataDimensionsInWrongOrderThrowsArgumentException()
+        {
+            // Arrange
+            byte[] data = Encoding.UTF8.GetBytes(DataReaderFixtures.MINIMAL_UTF8_20DATAVALUES);
+            using Stream stream = new MemoryStream(data);
+            using PxFileStreamDataReader reader = new(stream);
+            DoubleDataValue[] targetBuffer = new DoubleDataValue[20];
+
+            // Act
+            MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata([2, 2, 5]);
+            MatrixMap matrixMap = new(
+            [
+                new DimensionMap("var0", ["var0_val0", "var0_val1"]),
+                new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"]),
+                new DimensionMap("var1", ["var1_val0", "var1_val1"])
+            ]);
+
+            // Assert
+            Assert.ThrowsException<ArgumentException>(() => reader.ReadDoubleDataValues(targetBuffer, 0, testMeta, matrixMap));
         }
     }
 }

--- a/Px.Utils.UnitTests/PxFileTests/DataTests/PxFileStreamDataReaderTests/MultiPartReadingTests.cs
+++ b/Px.Utils.UnitTests/PxFileTests/DataTests/PxFileStreamDataReaderTests/MultiPartReadingTests.cs
@@ -1,11 +1,10 @@
 ﻿using Px.Utils.Models.Metadata;
 using Px.Utils.PxFile.Data;
-using Px.Utils.UnitTests;
 using PxFileTests.Fixtures;
 using Px.Utils.Models.Data.DataValue;
 using System.Text;
 
-namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
+namespace Px.Utils.UnitTests.PxFileTests.DataTests.PxFileStreamDataReaderTests
 {
     [TestClass]
     public class MultiPartReadingTests
@@ -23,28 +22,26 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             int[] testDimLengths_2_5_2 = [2, 5, 2];
 
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_5_2);
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
 
             double[] expected0 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer0);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap0, testMeta);
             CollectionAssert.AreEqual(expected0, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
 
             double[] expected1 = [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer1);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap1, testMeta);
             CollectionAssert.AreEqual(expected1, targetBuffer.Select(v => v.UnsafeValue).ToArray());
         }
 
@@ -60,28 +57,26 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             // Act and Assert
             int[] testDimLengths_2_5_2 = [2, 5, 2];
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_5_2);
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
 
             double[] expected0 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer0);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap0, testMeta);
             CollectionAssert.AreEqual(expected0, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
 
             double[] expected1 = [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer1);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap1, testMeta);
             CollectionAssert.AreEqual(expected1, targetBuffer.Select(v => v.UnsafeValue).ToArray());
         }
 
@@ -98,37 +93,34 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             int[] testDimLengths_2_2_5 = [2, 2, 5];
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_2_5);
 
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
             double[] expected0 = [0.0, 1.0, 2.0, 3.0, 4.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer0);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap0, testMeta);
             CollectionAssert.AreEqual(expected0, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
             double[] expected1 = [5.0, 6.0, 7.0, 8.0, 9.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer1);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap1, testMeta);
             CollectionAssert.AreEqual(expected1, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap2 = new(
+            MatrixMap targetMap2 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer2 = new(testMeta, matrixMap2);
             double[] expected2 = [10.0, 11.0, 12.0, 13.0, 14.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer2);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap2, testMeta);
             CollectionAssert.AreEqual(expected2, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
             MatrixMap matrixMap3 = new(
@@ -137,9 +129,8 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer3 = new(testMeta, matrixMap3);
             double[] expected3 = [15.0, 16.0, 17.0, 18.0, 19.0];
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer3);
+            reader.ReadDoubleDataValues(targetBuffer, 0, matrixMap3, testMeta);
             CollectionAssert.AreEqual(expected3, targetBuffer.Select(v => v.UnsafeValue).ToArray());
         }
 
@@ -156,64 +147,58 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             // Act and Assert
             int[] testDimLengths_2_2_5 = [2, 2, 5];
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_2_5);
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer0);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap0, testMeta);
             Assert.AreEqual(0.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val1"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer1);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap1, testMeta);
             Assert.AreEqual(1.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap2 = new(
+            MatrixMap targetMap2 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val4"])
             ]);
-            DataIndexer indexer2 = new(testMeta, matrixMap2);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer2);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap2, testMeta);
             Assert.AreEqual(9.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap3 = new(
+            MatrixMap targetMap3 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer3 = new(testMeta, matrixMap3);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer3);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap3, testMeta);
             Assert.AreEqual(10.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap4 = new(
+            MatrixMap targetMap4 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val1"])
             ]);
-            DataIndexer indexer4 = new(testMeta, matrixMap4);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer4);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap4, testMeta);
             Assert.AreEqual(11.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap5 = new(
+            MatrixMap targetMap5 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val4"])
             ]);
-            DataIndexer indexer5 = new(testMeta, matrixMap5);
-            reader.ReadDoubleDataValues(targetBuffer, 0, indexer5);
+            reader.ReadDoubleDataValues(targetBuffer, 0, targetMap5, testMeta);
             Assert.AreEqual(19.0, targetBuffer[0].UnsafeValue);
         }
 
@@ -230,28 +215,26 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             int[] testDimLengths_2_5_2 = [2, 5, 2];
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_5_2);
 
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
 
             double[] expected0 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer0);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap0, testMeta);
             CollectionAssert.AreEqual(expected0, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0", "var1_val1", "var1_val2", "var1_val3", "var1_val4"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
 
             double[] expected1 = [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0];
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer1);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap1, testMeta);
             CollectionAssert.AreEqual(expected1, targetBuffer.Select(v => v.UnsafeValue).ToArray());
         }
 
@@ -268,51 +251,47 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             int[] testDimLengths_2_2_5 = [2, 2, 5];
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_2_5);
 
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
             double[] expected0 = [0.0, 1.0, 2.0, 3.0, 4.0];
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer0);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap0, testMeta);
             CollectionAssert.AreEqual(expected0, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
 
             double[] expected1 = [5.0, 6.0, 7.0, 8.0, 9.0];
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer1);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap1, testMeta);
             CollectionAssert.AreEqual(expected1, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap2 = new(
+            MatrixMap targetMap2 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer2 = new(testMeta, matrixMap2);
 
             double[] expected2 = [10.0, 11.0, 12.0, 13.0, 14.0];
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer2);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap2, testMeta);
             CollectionAssert.AreEqual(expected2, targetBuffer.Select(v => v.UnsafeValue).ToArray());
 
-            MatrixMap matrixMap3 = new(
+            MatrixMap targetMap3 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val0", "var2_val1", "var2_val2", "var2_val3", "var2_val4"])
             ]);
-            DataIndexer indexer3 = new(testMeta, matrixMap3);
 
             double[] expected3 = [15.0, 16.0, 17.0, 18.0, 19.0];
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer3);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap3, testMeta);
             CollectionAssert.AreEqual(expected3, targetBuffer.Select(v => v.UnsafeValue).ToArray());
         }
 
@@ -329,64 +308,58 @@ namespace PxFileTests.DataTests.PxFileStreamDataReaderTests
             int[] testDimLengths_2_2_5 = [2, 2, 5];
             MatrixMetadata testMeta = TestModelBuilder.BuildTestMetadata(testDimLengths_2_2_5);
 
-            MatrixMap matrixMap0 = new(
+            MatrixMap targetMap0 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer0 = new(testMeta, matrixMap0);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer0);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap0, testMeta);
             Assert.AreEqual(0.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap1 = new(
+            MatrixMap targetMap1 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val1"])
             ]);
-            DataIndexer indexer1 = new(testMeta, matrixMap1);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer1);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap1, testMeta);
             Assert.AreEqual(1.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap2 = new(
+            MatrixMap targetMap2 = new(
             [
                 new DimensionMap("var0", ["var0_val0"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val4"])
             ]);
-            DataIndexer indexer2 = new(testMeta, matrixMap2);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer2);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap2, testMeta);
             Assert.AreEqual(9.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap3 = new(
+            MatrixMap targetMap3 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val0"])
             ]);
-            DataIndexer indexer3 = new(testMeta, matrixMap3);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer3);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap3, testMeta);
             Assert.AreEqual(10.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap4 = new(
+            MatrixMap targetMap4 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val0"]),
                 new DimensionMap("var2", ["var2_val1"])
             ]);
-            DataIndexer indexer4 = new(testMeta, matrixMap4);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer4);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap4, testMeta);
             Assert.AreEqual(11.0, targetBuffer[0].UnsafeValue);
 
-            MatrixMap matrixMap5 = new(
+            MatrixMap targetMap5 = new(
             [
                 new DimensionMap("var0", ["var0_val1"]),
                 new DimensionMap("var1", ["var1_val1"]),
                 new DimensionMap("var2", ["var2_val4"])
             ]);
-            DataIndexer indexer5 = new(testMeta, matrixMap5);
-            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, indexer5);
+            await reader.ReadDoubleDataValuesAsync(targetBuffer, 0, targetMap5, testMeta);
             Assert.AreEqual(19.0, targetBuffer[0].UnsafeValue);
         }
     }

--- a/Px.Utils/Models/Metadata/ExtensionMethods/MatrixMapExtensions.cs
+++ b/Px.Utils/Models/Metadata/ExtensionMethods/MatrixMapExtensions.cs
@@ -34,5 +34,35 @@
             }
             return new MatrixMap(newDimensionMaps);
         }
+
+        /// <summary>
+        /// Checks if the other map contains the same dimensions and values as this map in the same order.
+        /// The other map can contain values that are not found in this map.
+        /// </summary>
+        /// <returns>True if all of the values are found in the correct order.</returns>
+        public static bool IsSubmapOf(this IMatrixMap thisMap, IMatrixMap other)
+        {
+            if(thisMap.DimensionMaps.Count != other.DimensionMaps.Count) return false;
+            for (int i = 0; i < thisMap.DimensionMaps.Count; i++)
+            {
+                if (other.DimensionMaps[i].Code != thisMap.DimensionMaps[i].Code) return false;
+                int sourceIndex = 0;
+                for (int j = 0; j < thisMap.DimensionMaps[i].ValueCodes.Count; j++)
+                {
+                    bool found = false;
+                    for(int k = sourceIndex; k < other.DimensionMaps[i].ValueCodes.Count; k++)
+                    {
+                        if (other.DimensionMaps[i].ValueCodes[k] == thisMap.DimensionMaps[i].ValueCodes[j])
+                        {
+                            sourceIndex = k + 1;
+                            found = true;
+                            break;
+                        }
+                    }
+                    if(!found) return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/Px.Utils/PxFile/Data/IPxFileStreamDataReader.cs
+++ b/Px.Utils/PxFile/Data/IPxFileStreamDataReader.cs
@@ -1,4 +1,5 @@
 ﻿using Px.Utils.Models.Data.DataValue;
+using Px.Utils.Models.Metadata;
 
 namespace Px.Utils.PxFile.Data
 {
@@ -9,34 +10,38 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
         /// <param name="missingValueEncodings"> An array of <see cref="double"/> values that represent missing data.</param>
-        public void ReadUnsafeDoubles(double[] buffer, int offset, DataIndexer indexer, double[] missingValueEncodings);
+        public void ReadUnsafeDoubles(double[] buffer, int offset, IMatrixMap target, IMatrixMap complete, double[] missingValueEncodings);
 
         /// <summary>
         /// Reads a specified set of data values into a buffer as <see cref="DoubleDataValue"/> instances.
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public void ReadDoubleDataValues(DoubleDataValue[] buffer, int offset, DataIndexer indexer);
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
+        public void ReadDoubleDataValues(DoubleDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete);
 
         /// <summary>
         /// Reads a specified set of data values into a buffer as <see cref="DecimalDataValue"/> instances.
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public void ReadDecimalDataValues(DecimalDataValue[] buffer, int offset, DataIndexer indexer);
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
+        public void ReadDecimalDataValues(DecimalDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete);
 
         /// <summary>
         /// Asynchronously reads a specified set of data values into a buffer as <see cref="double"/>s.
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
         /// <param name="missingValueEncodings"> An array of <see cref="double"/> values that represent missing data.</param>
-        public Task ReadUnsafeDoublesAsync(double[] buffer, int offset, DataIndexer indexer, double[] missingValueEncodings);
+        public Task ReadUnsafeDoublesAsync(double[] buffer, int offset, IMatrixMap target, IMatrixMap complete, double[] missingValueEncodings);
 
         /// <summary>
         /// Asynchronously reads a specified set of data values into a buffer as <see cref="double"/>s.
@@ -44,18 +49,20 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
         /// <param name="missingValueEncodings"> An array of double values that represent missing data.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        public Task ReadUnsafeDoublesAsync(double[] buffer, int offset, DataIndexer indexer, double[] missingValueEncodings, CancellationToken cancellationToken);
+        public Task ReadUnsafeDoublesAsync(double[] buffer, int offset, IMatrixMap target, IMatrixMap complete, double[] missingValueEncodings, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously reads a specified set of data values into a buffer as <see cref="DoubleDataValue"/> instances.
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, DataIndexer indexer);
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
+        public Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete);
 
         /// <summary>
         /// Asynchronously reads a specified set of data values into a buffer as <see cref="DoubleDataValue"/> instances.
@@ -63,17 +70,19 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
         /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
-        public Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, DataIndexer indexer, CancellationToken cancellationToken);
+        public Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete, CancellationToken cancellationToken);
 
         /// <summary>
         /// Asynchronously reads a specified set of data values into a buffer as <see cref="DecimalDataValue"/> instances.
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, DataIndexer indexer);
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
+        public Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete);
 
         /// <summary>
         /// Asynchronously reads a specified set of data values into a buffer as <see cref="DecimalDataValue"/> instances.
@@ -81,8 +90,9 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">The target matrix map to read the data from.</param>
+        /// <param name="complete">The complete matrix map to read the data from.</param>
         /// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
-        public Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, DataIndexer indexer, CancellationToken cancellationToken);
+        public Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete, CancellationToken cancellationToken);
     }
 }

--- a/Px.Utils/PxFile/Data/PxFileStreamDataReader.cs
+++ b/Px.Utils/PxFile/Data/PxFileStreamDataReader.cs
@@ -1,4 +1,6 @@
 ﻿using Px.Utils.Models.Data.DataValue;
+using Px.Utils.Models.Metadata;
+using Px.Utils.Models.Metadata.ExtensionMethods;
 
 namespace Px.Utils.PxFile.Data
 {
@@ -55,7 +57,8 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
         /// <param name="missingValueEncodings">
         /// An array of <see cref="double"/> values that represent missing data in the PX file in the following order:
         /// [0] "-"
@@ -66,11 +69,12 @@ namespace Px.Utils.PxFile.Data
         /// [5] "....."
         /// [6] "......"
         /// </param>
-        public void ReadUnsafeDoubles(double[] buffer, int offset, DataIndexer indexer, double[] missingValueEncodings)
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>"
+        public void ReadUnsafeDoubles(double[] buffer, int offset, IMatrixMap target, IMatrixMap complete, double[] missingValueEncodings)
         {
             SetReaderPositionIfZero();
-            ReadItemsFromStreamByCoordinate(buffer, offset, indexer, Parser);
-            
+            ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, Parser);
+
             double Parser(char[] parseBuffer, int len)
             {
                 return DataValueParsers.FastParseUnsafeDoubleDangerous(parseBuffer, len, missingValueEncodings);
@@ -84,11 +88,13 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public void ReadDoubleDataValues(DoubleDataValue[] buffer, int offset, DataIndexer indexer)
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>""
+        public void ReadDoubleDataValues(DoubleDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete)
         {
             SetReaderPositionIfZero();
-            ReadItemsFromStreamByCoordinate(buffer, offset, indexer, DataValueParsers.FastParseDoubleDataValueDangerous);
+            ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, DataValueParsers.FastParseDoubleDataValueDangerous);
         }
 
         /// <summary>
@@ -98,11 +104,13 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public void ReadDecimalDataValues(DecimalDataValue[] buffer, int offset, DataIndexer indexer)
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>
+        public void ReadDecimalDataValues(DecimalDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete)
         {
             SetReaderPositionIfZero();
-            ReadItemsFromStreamByCoordinate(buffer, offset, indexer, DataValueParsers.FastParseDecimalDataValueDangerous);
+            ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, DataValueParsers.FastParseDecimalDataValueDangerous);
         }
 
         #endregion
@@ -116,7 +124,8 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
         /// <param name="missingValueEncodings">
         /// An array of <see cref="double"/> values that represent missing data in the PX file in the following order:
         /// [0] "-"
@@ -127,11 +136,12 @@ namespace Px.Utils.PxFile.Data
         /// [5] "....."
         /// [6] "......"
         /// </param>
-        public async Task ReadUnsafeDoublesAsync(double[] buffer, int offset, DataIndexer indexer, double[] missingValueEncodings)
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>"
+        public async Task ReadUnsafeDoublesAsync(double[] buffer, int offset, IMatrixMap target, IMatrixMap complete, double[] missingValueEncodings)
         {
             await SetReaderPositionIfZeroAsync();
             await Task.Factory.StartNew(() =>
-                ReadItemsFromStreamByCoordinate(buffer, offset, indexer, Parser));
+                ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, Parser));
 
             double Parser(char[] parseBuffer, int len)
             {
@@ -147,7 +157,8 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
         /// <param name="missingValueEncodings">
         /// An array of <see cref="double"/> values that represent missing data in the PX file in the following order:
         /// [0] "-"
@@ -159,11 +170,12 @@ namespace Px.Utils.PxFile.Data
         /// [6] "......"
         /// </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        public async Task ReadUnsafeDoublesAsync(double[] buffer, int offset, DataIndexer indexer, double[] missingValueEncodings, CancellationToken cancellationToken)
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>"
+        public async Task ReadUnsafeDoublesAsync(double[] buffer, int offset, IMatrixMap target, IMatrixMap complete, double[] missingValueEncodings, CancellationToken cancellationToken)
         {
             await SetReaderPositionIfZeroAsync(cancellationToken);
             await Task.Factory.StartNew(() =>
-                ReadItemsFromStreamByCoordinate(buffer, offset, indexer, Parser, cancellationToken), cancellationToken);
+                ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, Parser, cancellationToken), cancellationToken);
 
             double Parser(char[] parseBuffer, int len)
             {
@@ -178,12 +190,14 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public async Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, DataIndexer indexer)
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>""
+        public async Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete)
         {
             await SetReaderPositionIfZeroAsync();
             await Task.Factory.StartNew(() =>
-                ReadItemsFromStreamByCoordinate(buffer, offset, indexer, DataValueParsers.FastParseDoubleDataValueDangerous));
+                ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, DataValueParsers.FastParseDoubleDataValueDangerous));
         }
 
         /// <summary>
@@ -194,13 +208,15 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        public async Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, DataIndexer indexer, CancellationToken cancellationToken)
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>
+        public async Task ReadDoubleDataValuesAsync(DoubleDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete, CancellationToken cancellationToken)
         {
             await SetReaderPositionIfZeroAsync(cancellationToken);
             await Task.Factory.StartNew(() =>
-                ReadItemsFromStreamByCoordinate(buffer, offset, indexer, DataValueParsers.FastParseDoubleDataValueDangerous, cancellationToken), cancellationToken);
+                ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, DataValueParsers.FastParseDoubleDataValueDangerous, cancellationToken), cancellationToken);
         }
 
         /// <summary>
@@ -210,12 +226,14 @@ namespace Px.Utils.PxFile.Data
         /// </summary>
         /// <param name="buffer">The buffer to store the read values.</param>
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
-        /// <param name="indexer">Provides the indexes where the data will be read.</param>
-        public async Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, DataIndexer indexer)
+        /// <param name="target">Map defining the data to be read. Must be a submap of the <paramref name="complete"/> map.</param>
+        /// <param name="complete">Map defining the complete data set.</param>
+        /// <exception cref="ArgumentException">Thrown when the target map is not a submap of the complete map.</exception>
+        public async Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete)
         {
             await SetReaderPositionIfZeroAsync();
             await Task.Factory.StartNew(() =>
-                ReadItemsFromStreamByCoordinate(buffer, offset, indexer, DataValueParsers.FastParseDecimalDataValueDangerous));
+                ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, DataValueParsers.FastParseDecimalDataValueDangerous));
         }
 
         /// <summary>
@@ -228,11 +246,11 @@ namespace Px.Utils.PxFile.Data
         /// <param name="offset">The starting index in the buffer to begin storing the read values.</param>
         /// <param name="indexer">Provides the indexes where the data will be read.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
-        public async Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, DataIndexer indexer, CancellationToken cancellationToken)
+        public async Task ReadDecimalDataValuesAsync(DecimalDataValue[] buffer, int offset, IMatrixMap target, IMatrixMap complete, CancellationToken cancellationToken)
         {
             await SetReaderPositionIfZeroAsync(cancellationToken);
             await Task.Factory.StartNew(() =>
-                ReadItemsFromStreamByCoordinate(buffer, offset, indexer, DataValueParsers.FastParseDecimalDataValueDangerous, cancellationToken), cancellationToken);
+                ReadItemsFromStreamByCoordinate(buffer, offset, target, complete, DataValueParsers.FastParseDecimalDataValueDangerous, cancellationToken), cancellationToken);
         }
 
         #endregion
@@ -275,8 +293,11 @@ namespace Px.Utils.PxFile.Data
             _stream.Position = start + dataKeyword.Length + 1; // +1 to skip the '='
         }
 
-        private void ReadItemsFromStreamByCoordinate<T>(T[] buffer, int offset, DataIndexer indexer, Func<char[], int, T> readItem, CancellationToken? token = null)
+        private void ReadItemsFromStreamByCoordinate<T>(T[] buffer, int offset, IMatrixMap target, IMatrixMap complete, Func<char[], int, T> readItem, CancellationToken? token = null)
         {
+            if(!target.IsSubmapOf(complete)) throw new ArgumentException("The target map is not a submap of the complete map.");
+            DataIndexer indexer = new(complete, target);
+
             int startingIndex = offset;
 
             byte[] internalBuffer = new byte[_readBufferSize];

--- a/Px.Utils/PxFile/Data/PxFileStreamDataReader.cs
+++ b/Px.Utils/PxFile/Data/PxFileStreamDataReader.cs
@@ -295,7 +295,7 @@ namespace Px.Utils.PxFile.Data
 
         private void ReadItemsFromStreamByCoordinate<T>(T[] buffer, int offset, IMatrixMap target, IMatrixMap complete, Func<char[], int, T> readItem, CancellationToken? token = null)
         {
-            if(!target.IsSubmapOf(complete)) throw new ArgumentException("The target map is not a submap of the complete map.");
+            if(!target.IsSubmapOf(complete)) throw new ArgumentException($"The {nameof(target)} map is not a submap of the {nameof(complete)} map.");
             DataIndexer indexer = new(complete, target);
 
             int startingIndex = offset;


### PR DESCRIPTION
- Changed the datareader interface to use maps instead of the indexer objects.
- Added checking that thet the target map is a submap of the complete map.
- Datareader now throws a exception if the data is beinf read in a wrong order.
- Updated the README