### PR TITLE
Meta data building property fixes

### DIFF
--- a/Px.Utils.UnitTests/ModelBuilderTests/Fixtures/PxFileMetaEntries_Robust_1_Language_With_Range_Time_Dimension.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/Fixtures/PxFileMetaEntries_Robust_1_Language_With_Range_Time_Dimension.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Px.Utils.UnitTests.ModelBuilderTests.Fixtures
+{
+    internal static class PxFileMetaEntries_Robust_1_Language_With_Range_Time_Dimension
+    {
+        public static List<KeyValuePair<string, string>> Entries =
+            [
+                new("CHARSET", "\"ANSI\""),
+                new("AXIS-VERSION", "\"2013\""),
+                new("CODEPAGE", "\"iso-8859-15\""),
+                new("LANGUAGE", "\"fi\""),
+                new("CREATION-DATE", "\"20200121 09:00\""),
+                new("NEXT-UPDATE", "\"20240131 08:00\""),
+                new("TABLEID", "\"example_table_id_for_testing\""),
+                new("DECIMALS", "0"),
+                new("SHOWDECIMALS", "1"),
+                new("MATRIX", "\"001_12ab_2022\""),
+                new("SUBJECT-CODE", "\"ABCD\""),
+                new("SUBJECT-AREA", "\"abcd\""),
+                new("COPYRIGHT", "YES"),
+                new("DESCRIPTION", "\"test_description_fi\""),
+                new("TITLE", "\"test_title_fi\""),
+                new("CONTENTS", "\"test_contents_fi\""),
+                new("UNITS", "\"test_unit_fi\""),
+                new("STUB", "\"Vuosi\",\"Alue\",\"Talotyyppi\""),
+                new("HEADING", "\"Tiedot\""),
+                new("CONTVARIABLE", "\"Tiedot\""),
+                new("VALUES(\"Vuosi\")", "\"2015\",\"2016\",\"2017\",\"2018\",\"2019\",\"2020\",\"2021\",\"2022\""),
+                new("VALUES(\"Alue\")", "\"Koko maa\",\"Pääkaupunkiseutu (PKS)\",\"Muu Suomi (koko maa pl. PKS)\",\"Helsinki\", \"Espoo-Kauniainen\",\"Vantaa\",\"Turku\""),
+                new("VALUES(\"Talotyyppi\")", "\"Talotyypit yhteensä\",\"Rivitalot\",\"Kerrostalot\""),
+                new("VALUES(\"Tiedot\")", "\"Indeksi (2015=100)\",\"Muutos edelliseen vuoteen (indeksi 2015=100)\",\"Kauppojen lukumäärä\""),
+                new("TIMEVAL(\"Vuosi\")", "TLIST(A1, \"2015-2022\")"),
+                new("CODES(\"Vuosi\")", "\"2015\",\"2016\",\"2017\",\"2018\",\"2019\",\"2020\",\"2021\",\"2022\""),
+                new("CODES(\"Alue\")", "\"ksu\",\"pks\",\"msu\",\"091\",\"049\",\"092\",\"853\""),
+                new("CODES(\"Talotyyppi\")", "\"0\",\"1\",\"3\""),
+                new("CODES(\"Tiedot\")", "\"ketjutettu_lv\",\"vmuutos_lv\",\"lkm_julk_uudet\""),
+                new("VARIABLE-TYPE(\"Vuosi\")", "\"Time\""),
+                new("VARIABLE-TYPE(\"Alue\")", "\"Classificatory\""),
+                new("VARIABLE-TYPE(\"Talotyyppi\")", "\"Classificatory\""),
+                new("MAP(\"Alue\")", "\"Alue 2018\""),
+                new("ELIMINATION(\"Talotyyppi\")", "\"Talotyypit yhteensä\""),
+                new("PRECISION(\"Tiedot\",\"Muutos edelliseen vuoteen (indeksi 2015=100)\")", "1"),
+                new("LAST-UPDATED(\"Indeksi (2015=100)\")", "\"20230131 08:00\""),
+                new("LAST-UPDATED(\"Muutos edelliseen vuoteen (indeksi 2015=100)\")", "\"20230131 09:00\""),
+                new("LAST-UPDATED(\"Kauppojen lukumäärä\")", "\"20230131 10:00\""),
+                new("UNITS(\"Indeksi (2015=100)\")", "\"indeksipisteluku\""),
+                new("UNITS(\"Muutos edelliseen vuoteen (indeksi 2015=100)\")", "\"%\""),
+                new("UNITS", "\"lukumäärä\""), // table level units
+                new("CONTACT(\"Indeksi (2015=100)\")", "\"test_contact1_fi\""),
+                new("CONTACT(\"Muutos edelliseen vuoteen (indeksi 2015=100)\")", "\"test_contact2_fi\""),
+                new("CONTACT(\"Kauppojen lukumäärä\")", "\"test_contact3_fi\""),
+                new("SOURCE", "\"test_source_fi\""),
+                new("OFFICIAL-STATISTICS", "YES"),
+                new("NOTE", "\"test_note_fi\""),
+                new("NOTE(\"Talotyyppi\")", "\"test_note_talotyyppi\""),
+                new("VALUENOTE(\"Tiedot\",\"Indeksi (2015=100)\")", "\"test_value_note_tiedot_indeksi\""),
+                new("VALUENOTE(\"Tiedot\",\"Muutos edelliseen vuoteen (indeksi 2015=100)\")", "\"test_value_note_tiedot_muutos\""),
+                new("VALUENOTE(\"Tiedot\",\"Kauppojen lukumäärä\")", "\"test_value_note_tiedot_kauppojen_lukumäärä\"")
+            ];
+    }
+}

--- a/Px.Utils.UnitTests/ModelBuilderTests/MatrixMetadataBuilderTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/MatrixMetadataBuilderTests.cs
@@ -20,6 +20,9 @@ namespace Px.Utils.UnitTests.ModelBuilderTests
         private MatrixMetadata Actual_1Lang_With_Table_Level_Units_And_Precision { get; } =
             new MatrixMetadataBuilder().Build(PxFileMetaEntries_Robust_1_Language_With_Table_Level_Units_And_Precision.Entries);
 
+        private MatrixMetadata Actual_1Lang_With_Range_Time_Dimension { get; } =
+            new MatrixMetadataBuilder().Build(PxFileMetaEntries_Robust_1_Language_With_Range_Time_Dimension.Entries);
+
         [TestMethod]
         public void IEnumerableBuildTest()
         {
@@ -524,6 +527,63 @@ namespace Px.Utils.UnitTests.ModelBuilderTests
             Assert.AreEqual(MetaPropertyType.MultilanguageTextArray, actual.AdditionalProperties["MULTILANGUAGETEXTARRAYPROPERTY"].Type);
             Assert.AreEqual(MetaPropertyType.TextArray, actual.AdditionalProperties["SINGLEITEMTEXTARRAYPROPERTY"].Type);
             Assert.AreEqual(MetaPropertyType.MultilanguageTextArray, actual.AdditionalProperties["SINGLEITEMMULTILANGUAGETEXTARRAYPROPERTY"].Type);
+        }
+
+        [TestMethod]
+        public void MultilanguageRemovesDimensionTypeAndTimeValEntriesTest()
+        {
+            Assert.IsTrue(Actual_1Lang_With_Range_Time_Dimension.Dimensions.Exists(dim => dim.Type == DimensionType.Time));
+            foreach (Dimension dim in Actual_3Lang.Dimensions)
+            {
+                Assert.IsFalse(dim.AdditionalProperties.ContainsKey(PxFileConfiguration.Default.Tokens.KeyWords.DimensionType));
+
+                if (dim.Type == DimensionType.Time)
+                {
+                    Assert.IsTrue(dim.AdditionalProperties.TryGetValue(PxFileConfiguration.Default.Tokens.KeyWords.TimeVal, out MetaProperty? value));
+                    Assert.AreEqual(MetaPropertyType.TextArray, value.Type);
+                    StringListProperty property = (StringListProperty)value;
+                    Assert.AreEqual(8, property.Value.Count);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MultilanguageWithRangeTimeDimensionTest()
+        {
+            Assert.IsTrue(Actual_1Lang_With_Range_Time_Dimension.Dimensions.Exists(dim => dim.Type == DimensionType.Time));
+            foreach (Dimension dim in Actual_1Lang_With_Range_Time_Dimension.Dimensions)
+            {
+                Assert.IsFalse(dim.AdditionalProperties.ContainsKey(PxFileConfiguration.Default.Tokens.KeyWords.DimensionType));
+
+                if (dim.Type == DimensionType.Time)
+                {
+                    Assert.IsTrue(dim.AdditionalProperties.ContainsKey(PxFileConfiguration.Default.Tokens.KeyWords.TimeVal));
+
+                    if (dim.Type == DimensionType.Time)
+                    {
+                        Assert.IsTrue(dim.AdditionalProperties.TryGetValue(PxFileConfiguration.Default.Tokens.KeyWords.TimeVal, out MetaProperty? value));
+                        Assert.AreEqual(MetaPropertyType.Text, value.Type);
+                        StringProperty property = (StringProperty)value;
+                        Assert.AreEqual("2015-2022", property.Value);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        public void MultilanguageRemovesTableLevelMetaEntriesTest()
+        {
+            string[] keywords = [
+                PxFileConfiguration.Default.Tokens.KeyWords.Units,
+                PxFileConfiguration.Default.Tokens.KeyWords.ShowDecimals,
+                PxFileConfiguration.Default.Tokens.KeyWords.Precision,
+                PxFileConfiguration.Default.Tokens.KeyWords.Decimals
+            ];
+
+            foreach (string keyword in keywords)
+            {
+                Assert.IsFalse(Actual_3Lang.AdditionalProperties.ContainsKey(keyword));
+            }
         }
     }
 }

--- a/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/GetTimeValValueStringTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/GetTimeValValueStringTests.cs
@@ -1,0 +1,48 @@
+﻿using Px.Utils.ModelBuilders;
+
+namespace Px.Utils.UnitTests.ModelBuilderTests.ValueParserUtilitiesTests
+{
+    [TestClass]
+    public class GetTimeValValueStringTests
+    {
+        [TestMethod]
+        public void GetTimeValValueStringTestEmptyInputReturnsEmptyString()
+        {
+            string input = "TLIST(A1)";
+            string expected = "";
+            string actual = ValueParserUtilities.GetTimeValValueString(input);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTimeValValueStringTestListInputReturnsEmptyString()
+        {
+            string input = "TLIST(A1), \"9000\", \"9001\", \"9002\", \"9003\", \"9004\"";
+            string expected = "";
+            string actual = ValueParserUtilities.GetTimeValValueString(input);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTimeValValueStringTestSingularInputReturnsEmptyString()
+        {
+            string input = "TLIST(A1, \"9001\")";
+            string expected = "";
+            string actual = ValueParserUtilities.GetTimeValValueString(input);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void GetTimeValueStringTestProperInputReturnsString()
+        {
+            string input = "TLIST(A1, \"9000-9001\")";
+            string expected = "9000-9001";
+            string actual = ValueParserUtilities.GetTimeValValueString(input);
+
+            Assert.AreEqual(expected, actual);
+        }
+    }
+}

--- a/Px.Utils/ModelBuilders/MatrixMetadataBuilder.cs
+++ b/Px.Utils/ModelBuilders/MatrixMetadataBuilder.cs
@@ -160,16 +160,20 @@ namespace Px.Utils.ModelBuilders
             {
                 string timeValValueString = timeValEntries.Values.First();
                 List<string> timeValList = ValueParserUtilities.GetTimeValValueList(timeValValueString, _conf);
-
+                MetaProperty timeValProperty = timeValList.Count > 0 ? new StringListProperty(timeValList) : new StringProperty(ValueParserUtilities.GetTimeValValueString(timeValValueString, _conf));
                 timeDimension = new(
                     code: GetDimensionCode(entries, langs, dimensionNameToTest),
                     name: dimensionNameToTest,
-                    additionalProperties: new() { { timeValIdentifierKey, new StringListProperty(timeValList) } },
+                    additionalProperties: new() { { timeValIdentifierKey, timeValProperty } },
                     values: GetDimensionValues(entries, langs, dimensionNameToTest),
                     interval: ValueParserUtilities.ParseTimeIntervalFromTimeVal(timeValValueString, _conf)
                     );
 
                 foreach (MetadataEntryKey key in timeValEntries.Keys) entries.Remove(key);
+                if (TryGetEntries(entries, dimensionTypeKey, langs, out Dictionary<MetadataEntryKey, string>? dimTypeEntries, dimensionNameToTest))
+                {
+                    foreach (MetadataEntryKey key in dimTypeEntries.Keys) entries.Remove(key);
+                }
                 return true;
             }
             else if (TryGetEntries(entries, dimensionTypeKey, langs, out Dictionary<MetadataEntryKey, string>? dimTypeEntries, dimensionNameToTest) &&
@@ -226,20 +230,26 @@ namespace Px.Utils.ModelBuilders
         {
             string code = GetDimensionCode(entries, langs, dimensionName);
             ContentValueList values = BuildContentDimensionValues(entries, langs, dimensionName);
-            // Table level UNIT, SHOWDECIMALS and DECIMALS properties are not needed after building the content dimension, so they're removed here
-            if (TryGetEntries(entries, _conf.Tokens.KeyWords.Units, langs, out Dictionary<MetadataEntryKey, string>? unitEntries))
-            {
-                foreach (MetadataEntryKey key in unitEntries.Keys) entries.Remove(key);
-            }
-            if (TryGetEntries(entries, _conf.Tokens.KeyWords.Decimals, langs, out Dictionary<MetadataEntryKey, string>? decimalEntries))
-            {
-                foreach (MetadataEntryKey key in decimalEntries.Keys) entries.Remove(key);
-            }
-            if (TryGetEntries(entries, _conf.Tokens.KeyWords.ShowDecimals, langs, out Dictionary<MetadataEntryKey, string>? showDecimalEntries))
-            {
-                foreach (MetadataEntryKey key in showDecimalEntries.Keys) entries.Remove(key);
-            }
+            // Table level UNIT, SHOWDECIMALS, PRECISION and DECIMALS properties are not needed after building the content dimension, so they're removed here
+            string[] keywords = [
+                _conf.Tokens.KeyWords.Units,
+                _conf.Tokens.KeyWords.ShowDecimals,
+                _conf.Tokens.KeyWords.Precision,
+                _conf.Tokens.KeyWords.Decimals
+            ];
+            RemoveEntries(entries, langs, keywords);
             return new ContentDimension(code, dimensionName, [], values);
+        }
+
+        private static void RemoveEntries(Dictionary<MetadataEntryKey, string> entries, PxFileLanguages langs, string[] tokens)
+        {
+            foreach (string token in tokens)
+            {
+                if (TryGetEntries(entries, token, langs, out Dictionary<MetadataEntryKey, string>? foundEntries))
+                {
+                    foreach (MetadataEntryKey key in foundEntries.Keys) entries.Remove(key);
+                }
+            }
         }
 
         private void AddAdditionalPropertiesToDimensions(

--- a/Px.Utils/ModelBuilders/ValueParserUtilities.cs
+++ b/Px.Utils/ModelBuilders/ValueParserUtilities.cs
@@ -79,6 +79,45 @@ namespace Px.Utils.ModelBuilders
         }
 
         /// <summary>
+        /// Removes the interval entry from the beginning of a time value string
+        /// and returns the rest as a string.
+        /// </summary>
+        /// <param name="input">The complete timeval value in one language.</param>
+        /// <param name="conf">Configuration used for parsing the value strings and the interval part.</param>
+        /// <returns>
+        /// Value string excluding the interval part.
+        /// If the input string is in the list format, empty string is returned.
+        /// </returns>
+        /// <exception cref="ArgumentException">If the input string does not match the expected timeval format.</exception>
+        public static string GetTimeValValueString(string input, PxFileConfiguration? conf = null)
+        {
+            conf ??= PxFileConfiguration.Default;
+
+            if (input.StartsWith(conf.Tokens.Time.TimeIntervalIndicator, StringComparison.InvariantCulture))
+            {
+                int endOftoken = conf.Tokens.Time.TimeIntervalIndicator.Length + 3; // 3 is the length of the characters between the interval indicator and the start of the value string
+                int firstStringDelimeter = input.IndexOf(conf.Symbols.Value.StringDelimeter, endOftoken);
+                if (firstStringDelimeter == -1 || 
+                    firstStringDelimeter > input.IndexOf(conf.Symbols.Value.TimeSeriesIntervalEnd, StringComparison.InvariantCulture) ||
+                    input.IndexOf(conf.Symbols.Value.TimeSeriesLimitsSeparator, firstStringDelimeter) == -1)
+                {
+                    return "";
+                }
+                int secondStringDelimeter = input.IndexOf(conf.Symbols.Value.StringDelimeter, firstStringDelimeter + 1);
+                if (firstStringDelimeter >= 0 &&
+                    secondStringDelimeter >= firstStringDelimeter)
+                {
+                    return input[firstStringDelimeter..secondStringDelimeter].CleanStringDelimeters(conf.Symbols.Value.StringDelimeter);
+                }
+                else return "";
+            }
+            else
+            {
+                throw new ArgumentException($"Invalid time value string {input}");
+            }
+        }
+
+        /// <summary>
         /// Parses a string into a <see cref="DimensionType"/> enumeration value.
         /// This method maps the input string to a <see cref="DimensionType"/> enumeration value based on the provided or default PxFileConfiguration configuration.
         /// If the input string does not map to a known <see cref="DimensionType"/>, the method returns <see cref="DimensionType.Unknown"/>.


### PR DESCRIPTION
- Removes dimension type meta properties from entries after building time dimension
- Stores range type time value indicator as string property 
- Removes table level precision keyword after building content dimension
Added tests to cover the cases