### PR TITLE
Added missing constructor parameter for content dimension values

### DIFF
--- a/Px.Utils.UnitTests/ModelBuilderTests/MatrixMetadataBuilderTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/MatrixMetadataBuilderTests.cs
@@ -374,6 +374,32 @@ namespace Px.Utils.UnitTests.ModelBuilderTests
             Assert.IsFalse(contentDimension?.Values[index].AdditionalProperties.ContainsKey("PRECISION"));
         }
 
+        [TestMethod]
+        public void MultiLangContentDimensionAdditionalPropertiesTest()
+        {
+            ContentDimension? contentDimension = (ContentDimension?)Actual_3Lang.Dimensions.Find(d => d.Type == DimensionType.Content);
+            Assert.IsNotNull(contentDimension);
+            Assert.AreEqual(3, contentDimension.Values.Count);
+            foreach (ContentDimensionValue value in contentDimension.Values)
+            {
+                Assert.IsTrue(value.AdditionalProperties.ContainsKey("VALUENOTE"));
+                Assert.IsInstanceOfType<MultilanguageStringProperty>(value.AdditionalProperties["VALUENOTE"]);
+            }
+        }
+
+        [TestMethod]
+        public void SingleLangContentDimensionAdditionalPropertiesTest()
+        {
+            ContentDimension? contentDimension = (ContentDimension?)Actual_1Lang.Dimensions.Find(d => d.Type == DimensionType.Content);
+            Assert.IsNotNull(contentDimension);
+            Assert.AreEqual(3, contentDimension.Values.Count);
+            foreach (ContentDimensionValue value in contentDimension.Values)
+            {
+                Assert.IsTrue(value.AdditionalProperties.ContainsKey("VALUENOTE"));
+                Assert.IsInstanceOfType<StringProperty>(value.AdditionalProperties["VALUENOTE"]);
+            }
+        }
+
         #endregion
 
         #region Time Dimension Tests

--- a/Px.Utils/Models/Metadata/Dimensions/ContentDimensionValue.cs
+++ b/Px.Utils/Models/Metadata/Dimensions/ContentDimensionValue.cs
@@ -104,7 +104,7 @@ namespace Px.Utils.Models.Metadata.Dimensions
             MultilanguageString unit,
             DateTime lastUpdated,
             int precision)
-            : base(dimensionValue.Code, dimensionValue.Name, dimensionValue.IsVirtual)
+            : base(dimensionValue.Code, dimensionValue.Name, dimensionValue.IsVirtual, dimensionValue.AdditionalProperties)
         {
             Unit = unit;
             LastUpdated = lastUpdated;


### PR DESCRIPTION
Addition properties are now added to content dimension values when constructor is called with dimension value as a parameter.
Added unit tests to catch simillar issues.