### PR TITLE
Added GetSizeLong() extension method for matrix maps

### DIFF
--- a/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
@@ -45,7 +45,7 @@ namespace Px.Utils.TestingApp.Commands
             Encoding encoding = reader.GetEncoding(fileStream);
             fileStream.Seek(0, SeekOrigin.Begin);
 
-            List<KeyValuePair<string, string>> entries = reader.ReadMetadata(fileStream, encoding).ToList();
+            List<KeyValuePair<string, string>> entries = [.. reader.ReadMetadata(fileStream, encoding)];
             MatrixMetadataBuilder builder = new();
             MetaData = builder.Build(entries);
         }
@@ -55,7 +55,7 @@ namespace Px.Utils.TestingApp.Commands
             if(MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DoubleDataValue[] buffer = new DoubleDataValue[Target.GetSize()];
+            DoubleDataValue[] buffer = new DoubleDataValue[Target.GetSizeLong()];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -68,7 +68,7 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DecimalDataValue[] buffer = new DecimalDataValue[Target.GetSize()];
+            DecimalDataValue[] buffer = new DecimalDataValue[Target.GetSizeLong()];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -81,7 +81,7 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            double[] buffer = new double[Target.GetSize()];
+            double[] buffer = new double[Target.GetSizeLong()];
             double[] missingValueEncodings = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
@@ -95,7 +95,7 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DoubleDataValue[] buffer = new DoubleDataValue[Target.GetSize()];
+            DoubleDataValue[] buffer = new DoubleDataValue[Target.GetSizeLong()];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -108,7 +108,7 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DecimalDataValue[] buffer = new DecimalDataValue[Target.GetSize()];
+            DecimalDataValue[] buffer = new DecimalDataValue[Target.GetSizeLong()];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -121,7 +121,7 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            double[] buffer = new double[Target.GetSize()];
+            double[] buffer = new double[Target.GetSizeLong()];
             double[] missingValueEncodings = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
@@ -145,7 +145,7 @@ namespace Px.Utils.TestingApp.Commands
 
         private static IMatrixMap GenerateBenchmarkTargetMap(IMatrixMap complete, int targetSize)
         {
-            int size = complete.GetSize();
+            long size = complete.GetSizeLong();
             if (size < targetSize) return complete;
 
             List<IDimensionMap> sortedDimensions = [.. complete.DimensionMaps];
@@ -157,13 +157,12 @@ namespace Px.Utils.TestingApp.Commands
                 size = sortedDimensions.Aggregate(1, (acc, x) => acc * x.ValueCodes.Count);
             }
 
-            List<IDimensionMap> dimList = complete.DimensionMaps
+            List<IDimensionMap> dimList = [.. complete.DimensionMaps
                 .Select(dim => dim.Code)
                 .Select(dimCode => new DimensionMap(
                     dimCode,
                     [.. sortedDimensions.First(dim => dim.Code == dimCode).ValueCodes]))
-                .Cast<IDimensionMap>()
-                .ToList();
+                .Cast<IDimensionMap>()];
 
             return new MatrixMap(dimList);
         }

--- a/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
@@ -55,7 +55,10 @@ namespace Px.Utils.TestingApp.Commands
             if(MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DoubleDataValue[] buffer = new DoubleDataValue[Target.GetSizeLong()];
+            int arraySize = Target.GetSizeLong() > int.MaxValue
+                ? throw new InvalidOperationException("Target size exceeds maximum array size.")
+                : (int)Target.GetSizeLong();
+            DoubleDataValue[] buffer = new DoubleDataValue[arraySize];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -68,7 +71,10 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DecimalDataValue[] buffer = new DecimalDataValue[Target.GetSizeLong()];
+            int arraySize = Target.GetSizeLong() > int.MaxValue
+                ? throw new InvalidOperationException("Target size exceeds maximum array size.")
+                : (int)Target.GetSizeLong();
+            DecimalDataValue[] buffer = new DecimalDataValue[arraySize];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -81,7 +87,10 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            double[] buffer = new double[Target.GetSizeLong()];
+            int arraySize = Target.GetSizeLong() > int.MaxValue
+                ? throw new InvalidOperationException("Target size exceeds maximum array size.")
+                : (int)Target.GetSizeLong();
+            double[] buffer = new double[arraySize];
             double[] missingValueEncodings = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
@@ -95,7 +104,10 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DoubleDataValue[] buffer = new DoubleDataValue[Target.GetSizeLong()];
+            int arraySize = Target.GetSizeLong() > int.MaxValue
+                ? throw new InvalidOperationException("Target size exceeds maximum array size.")
+                : (int)Target.GetSizeLong();
+            DoubleDataValue[] buffer = new DoubleDataValue[arraySize];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -108,7 +120,10 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            DecimalDataValue[] buffer = new DecimalDataValue[Target.GetSizeLong()];
+            int arraySize = Target.GetSizeLong() > int.MaxValue
+                ? throw new InvalidOperationException("Target size exceeds maximum array size.")
+                : (int)Target.GetSizeLong();
+            DecimalDataValue[] buffer = new DecimalDataValue[arraySize];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);
             using PxFileStreamDataReader reader = new(stream);
@@ -121,7 +136,10 @@ namespace Px.Utils.TestingApp.Commands
             if (MetaData is null) throw new InvalidOperationException(metadataNotFoundMessage);
             Target = GenerateBenchmarkTargetMap(MetaData, _numberOfCells);
 
-            double[] buffer = new double[Target.GetSizeLong()];
+            int arraySize = Target.GetSizeLong() > int.MaxValue
+                ? throw new InvalidOperationException("Target size exceeds maximum array size.")
+                : (int)Target.GetSizeLong();
+            double[] buffer = new double[arraySize];
             double[] missingValueEncodings = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
 
             using Stream stream = new FileStream(TestFilePath, FileMode.Open, FileAccess.Read);

--- a/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
@@ -171,7 +171,7 @@ namespace Px.Utils.TestingApp.Commands
             {
                 sortedDimensions = [.. sortedDimensions.OrderByDescending(x => x.ValueCodes.Count)];
                 IReadOnlyList<string> valCodes = sortedDimensions[0].ValueCodes;
-                sortedDimensions[0] = new DimensionMap(sortedDimensions[0].Code, valCodes.Skip(1).ToList());
+                sortedDimensions[0] = new DimensionMap(sortedDimensions[0].Code, [.. valCodes.Skip(1)]);
                 size = sortedDimensions.Aggregate(1L, (acc, x) => acc * x.ValueCodes.Count);
             }
 

--- a/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
+++ b/Px.Utils.TestingApp/Commands/DataReadBenchmark.cs
@@ -23,7 +23,7 @@ namespace Px.Utils.TestingApp.Commands
 
         private IMatrixMap? Target { get; set; }
 
-        private int _numberOfCells = 1000000;
+        private long _numberOfCells = 1000000L;
 
         private static readonly string[] cellFlags = ["-c", "-cells"];
 
@@ -154,14 +154,14 @@ namespace Px.Utils.TestingApp.Commands
 
             foreach (string key in Parameters.Keys)
             {
-                if (cellFlags.Contains(key) && !int.TryParse(Parameters[key][0], out _numberOfCells))
+                if (cellFlags.Contains(key) && !long.TryParse(Parameters[key][0], out _numberOfCells))
                 {
                     throw new ArgumentException($"Invalid argument {key} {string.Join(' ', Parameters[key])}");
                 }
             }
         }
 
-        private static IMatrixMap GenerateBenchmarkTargetMap(IMatrixMap complete, int targetSize)
+        private static IMatrixMap GenerateBenchmarkTargetMap(IMatrixMap complete, long targetSize)
         {
             long size = complete.GetSizeLong();
             if (size < targetSize) return complete;
@@ -170,9 +170,9 @@ namespace Px.Utils.TestingApp.Commands
             while (size > targetSize)
             {
                 sortedDimensions = [.. sortedDimensions.OrderByDescending(x => x.ValueCodes.Count)];
-                var valCodes = sortedDimensions[0].ValueCodes;
+                IReadOnlyList<string> valCodes = sortedDimensions[0].ValueCodes;
                 sortedDimensions[0] = new DimensionMap(sortedDimensions[0].Code, valCodes.Skip(1).ToList());
-                size = sortedDimensions.Aggregate(1, (acc, x) => acc * x.ValueCodes.Count);
+                size = sortedDimensions.Aggregate(1L, (acc, x) => acc * x.ValueCodes.Count);
             }
 
             List<IDimensionMap> dimList = [.. complete.DimensionMaps

--- a/Px.Utils.UnitTests/ModelTests/ExtensionTests/MatrixMapExtensionTests.cs
+++ b/Px.Utils.UnitTests/ModelTests/ExtensionTests/MatrixMapExtensionTests.cs
@@ -593,6 +593,7 @@ namespace Px.Utils.UnitTests.ModelTests.ExtensionTests
         #region GetSize
 
         [TestMethod]
+        [Obsolete("GetSize() method is marked obsolete.")]
         public void GetSizeWithValidMapReturnsCorrectSize()
         {
             // Arrange
@@ -609,6 +610,7 @@ namespace Px.Utils.UnitTests.ModelTests.ExtensionTests
         }
 
         [TestMethod]
+        [Obsolete("GetSize() method is marked obsolete.")]
         public void GetSizeWithZeroSizedDimensionReturnsZero()
         {
             // Arrange
@@ -626,9 +628,171 @@ namespace Px.Utils.UnitTests.ModelTests.ExtensionTests
 
         #endregion
 
+        #region GetSizeLong
+
+        [TestMethod]
+        public void GetSizeLongWithValidMapReturnsCorrectSize()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                new DimensionMap("22", ["aa22", "bb22"]),
+                new DimensionMap("33", ["aa33"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (3 * 2 * 1 = 6)
+            Assert.AreEqual(6L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithZeroSizedDimensionReturnsZero()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("11", ["aa11", "bb11", "cc11"]),
+                new DimensionMap("22", []),
+                new DimensionMap("33", ["aa33"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (x * 0 = 0)
+            Assert.AreEqual(0L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithSingleDimensionReturnsCorrectSize()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("11", ["aa11", "bb11", "cc11", "dd11", "ee11"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert
+            Assert.AreEqual(5L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithEmptyMapReturnsOne()
+        {
+            // Arrange
+            MatrixMap map = new([]);
+
+            // Act and Assert
+            Assert.AreEqual(1L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithLargeDimensionsReturnsCorrectSize()
+        {
+            // Arrange - Create dimensions that would result in a large number
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("dim1", Enumerable.Range(0, 100).Select(i => $"val{i}").ToList()),
+                new DimensionMap("dim2", Enumerable.Range(0, 50).Select(i => $"val{i}").ToList()),
+                new DimensionMap("dim3", Enumerable.Range(0, 10).Select(i => $"val{i}").ToList())
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (100 * 50 * 10 = 50,000)
+            Assert.AreEqual(50000L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithVeryLargeDimensionsHandlesLongRange()
+        {
+            // Arrange - Create dimensions that would overflow int but fit in long
+            // This simulates a case where GetSize() would fail but GetSizeLong() should work
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("dim1", Enumerable.Range(0, 1000).Select(i => $"val{i}").ToList()),
+                new DimensionMap("dim2", Enumerable.Range(0, 1000).Select(i => $"val{i}").ToList()),
+                new DimensionMap("dim3", Enumerable.Range(0, 5).Select(i => $"val{i}").ToList())
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (1000 * 1000 * 5 = 5,000,000)
+            Assert.AreEqual(5000000L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithOneDimensionOfSizeOneReturnsCorrectSize()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("dim1", ["val1"]),
+                new DimensionMap("dim2", ["val1", "val2", "val3"]),
+                new DimensionMap("dim3", ["val1", "val2"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (1 * 3 * 2 = 6)
+            Assert.AreEqual(6L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithMultipleDimensionsOfSizeOneReturnsOne()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("dim1", ["val1"]),
+                new DimensionMap("dim2", ["val1"]),
+                new DimensionMap("dim3", ["val1"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (1 * 1 * 1 = 1)
+            Assert.AreEqual(1L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongWithManySmallDimensionsReturnsCorrectSize()
+        {
+            // Arrange - Test with many dimensions with small sizes
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("dim1", ["val1", "val2"]),
+                new DimensionMap("dim2", ["val1", "val2"]),
+                new DimensionMap("dim3", ["val1", "val2"]),
+                new DimensionMap("dim4", ["val1", "val2"]),
+                new DimensionMap("dim5", ["val1", "val2"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act and Assert (2^5 = 32)
+            Assert.AreEqual(32L, map.GetSizeLong());
+        }
+
+        [TestMethod]
+        public void GetSizeLongReturnsLongType()
+        {
+            // Arrange
+            List<IDimensionMap> dimensions = [
+                new DimensionMap("dim1", ["val1", "val2"]),
+                new DimensionMap("dim2", ["val1", "val2", "val3"])
+            ];
+
+            MatrixMap map = new(dimensions);
+
+            // Act
+            var result = map.GetSizeLong();
+
+            // Assert - Verify return type is long
+            Assert.IsInstanceOfType<long>(result);
+            Assert.AreEqual(6L, result);
+        }
+
+        #endregion
+
         #region CollapseDimension
 
-                [TestMethod]
+        [TestMethod]
         public void CollapseDimensionWithValidMapReturnsCollapsedMap()
         {
             // Arrange
@@ -644,7 +808,7 @@ namespace Px.Utils.UnitTests.ModelTests.ExtensionTests
             IMatrixMap collapsedMap = map.CollapseDimension("22", "foo");
 
             // Assert
-            Assert.AreEqual(9, collapsedMap.GetSize()); // 3 * 1 * 3 = 9
+            Assert.AreEqual(9, collapsedMap.GetSizeLong()); // 3 * 1 * 3 = 9
             Assert.AreEqual(1, collapsedMap.DimensionMaps[1].ValueCodes.Count);
             Assert.AreEqual("foo", collapsedMap.DimensionMaps[1].ValueCodes[0]);
         }

--- a/Px.Utils.UnitTests/ModelTests/ExtensionTests/MatrixMapExtensionTests.cs
+++ b/Px.Utils.UnitTests/ModelTests/ExtensionTests/MatrixMapExtensionTests.cs
@@ -808,7 +808,7 @@ namespace Px.Utils.UnitTests.ModelTests.ExtensionTests
             IMatrixMap collapsedMap = map.CollapseDimension("22", "foo");
 
             // Assert
-            Assert.AreEqual(9, collapsedMap.GetSizeLong()); // 3 * 1 * 3 = 9
+            Assert.AreEqual(9L, collapsedMap.GetSizeLong()); // 3 * 1 * 3 = 9
             Assert.AreEqual(1, collapsedMap.DimensionMaps[1].ValueCodes.Count);
             Assert.AreEqual("foo", collapsedMap.DimensionMaps[1].ValueCodes[0]);
         }

--- a/Px.Utils/Models/Metadata/ExtensionMethods/MatrixMapExtensions.cs
+++ b/Px.Utils/Models/Metadata/ExtensionMethods/MatrixMapExtensions.cs
@@ -7,7 +7,7 @@
         /// </summary>
         /// <param name="matrixMap">The matrix map.</param>
         /// <returns>Total number of cells in the matrix described by the matrix map.</returns>
-        [Obsolete("Use GetSizeULong() instead. This method can overflow with really large tables.")]
+        [Obsolete("Use GetSizeLong() instead. This method can overflow with really large tables.")]
         public static int GetSize(this IMatrixMap matrixMap)
         {
             int numberOfCells = 1;

--- a/Px.Utils/Models/Metadata/ExtensionMethods/MatrixMapExtensions.cs
+++ b/Px.Utils/Models/Metadata/ExtensionMethods/MatrixMapExtensions.cs
@@ -7,9 +7,25 @@
         /// </summary>
         /// <param name="matrixMap">The matrix map.</param>
         /// <returns>Total number of cells in the matrix described by the matrix map.</returns>
+        [Obsolete("Use GetSizeULong() instead. This method can overflow with really large tables.")]
         public static int GetSize(this IMatrixMap matrixMap)
         {
             int numberOfCells = 1;
+            foreach (IDimensionMap dimensionMap in matrixMap.DimensionMaps)
+            {
+                numberOfCells *= dimensionMap.ValueCodes.Count;
+            }
+            return numberOfCells;
+        }
+
+        /// <summary>
+        /// Returns the total number of cells in the matrix described by the matrix map.
+        /// </summary>
+        /// <param name="matrixMap">The matrix map.</param>
+        /// <returns>Total number of cells in the matrix described by the matrix map.</returns>
+        public static long GetSizeLong(this IMatrixMap matrixMap)
+        {
+            long numberOfCells = 1;
             foreach (IDimensionMap dimensionMap in matrixMap.DimensionMaps)
             {
                 numberOfCells *= dimensionMap.ValueCodes.Count;

--- a/Px.Utils/Operations/MatrixFunctionExtensions.cs
+++ b/Px.Utils/Operations/MatrixFunctionExtensions.cs
@@ -32,7 +32,7 @@ namespace Px.Utils.Operations
             IMatrixMap resultOnlyMap = newMeta.CollapseDimension(sourceMap.Code, newValue.Code);
             long arraySize = input.Metadata.GetSizeLong() + resultOnlyMap.GetSizeLong();
             if (arraySize > int.MaxValue) throw new InvalidOperationException("Resulting matrix size exceeds maximum array size.");
-            TData[] outData = new TData[arraySize];
+            TData[] outData = new TData[(int)arraySize];
 
             // Initialize the output matrix with the identity value
             for (int i = 0; i < outData.Length; i++) outData[i] = functionIdentity; 

--- a/Px.Utils/Operations/MatrixFunctionExtensions.cs
+++ b/Px.Utils/Operations/MatrixFunctionExtensions.cs
@@ -30,7 +30,7 @@ namespace Px.Utils.Operations
                 : CopyMetaAndInsertValue(input.Metadata, sourceMap.Code, newValue, valueIndex);
 
             IMatrixMap resultOnlyMap = newMeta.CollapseDimension(sourceMap.Code, newValue.Code);
-            TData[] outData = new TData[input.Metadata.GetSize() + resultOnlyMap.GetSize()];
+            TData[] outData = new TData[input.Metadata.GetSizeLong() + resultOnlyMap.GetSizeLong()];
             
             // Initialize the output matrix with the identity value
             for (int i = 0; i < outData.Length; i++) outData[i] = functionIdentity; 

--- a/Px.Utils/Operations/MatrixFunctionExtensions.cs
+++ b/Px.Utils/Operations/MatrixFunctionExtensions.cs
@@ -30,8 +30,10 @@ namespace Px.Utils.Operations
                 : CopyMetaAndInsertValue(input.Metadata, sourceMap.Code, newValue, valueIndex);
 
             IMatrixMap resultOnlyMap = newMeta.CollapseDimension(sourceMap.Code, newValue.Code);
-            TData[] outData = new TData[input.Metadata.GetSizeLong() + resultOnlyMap.GetSizeLong()];
-            
+            long arraySize = input.Metadata.GetSizeLong() + resultOnlyMap.GetSizeLong();
+            if (arraySize > int.MaxValue) throw new InvalidOperationException("Resulting matrix size exceeds maximum array size.");
+            TData[] outData = new TData[arraySize];
+
             // Initialize the output matrix with the identity value
             for (int i = 0; i < outData.Length; i++) outData[i] = functionIdentity; 
 


### PR DESCRIPTION
Marked GetSize() as obsolete, since there is a risk that with truly large tables this may cause overflow issues.