### PR TITLE
[Fix] Dimension type validation false positive

### DIFF
--- a/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
@@ -39,7 +39,7 @@ namespace Px.Utils.UnitTests.ModelBuilderTests.ValueParserUtilitiesTests
         {
             string input = "Ranking";
             PxFileConfiguration conf = PxFileConfiguration.Default;
-            conf.Tokens.VariableTypes.Ordinal = ["Ordinal", "Ranking"];
+            conf.Tokens.VariableTypes.Mappings["Ranking"] = DimensionType.Ordinal;
 
             DimensionType expected = DimensionType.Ordinal;
             DimensionType actual = ValueParserUtilities.StringToDimensionType(input, conf);

--- a/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
@@ -17,16 +17,7 @@ namespace Px.Utils.UnitTests.ModelBuilderTests.ValueParserUtilitiesTests
         }
 
         [TestMethod]
-        public void ContentTest()
-        {
-            string input = "Content";
-            DimensionType expected = DimensionType.Content;
-            DimensionType actual = ValueParserUtilities.StringToDimensionType(input);
-            Assert.AreEqual(expected, actual);
-        }
-
-        [TestMethod]
-        public void ContentAliasTest()
+        public void ContentsTest()
         {
             string input = "Contents";
             DimensionType expected = DimensionType.Content;

--- a/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
@@ -1,7 +1,8 @@
-﻿using Px.Utils.ModelBuilders;
+using Px.Utils.ModelBuilders;
 using Px.Utils.Models.Metadata.Enums;
+using Px.Utils.PxFile;
 
-namespace ModelBuilderTests.ValueParserUtilitiesTests
+namespace Px.Utils.UnitTests.ModelBuilderTests.ValueParserUtilitiesTests
 {
     [TestClass]
     public class StringToDimensionTypeTests
@@ -21,6 +22,27 @@ namespace ModelBuilderTests.ValueParserUtilitiesTests
             string input = "Content";
             DimensionType expected = DimensionType.Content;
             DimensionType actual = ValueParserUtilities.StringToDimensionType(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void ContentAliasTest()
+        {
+            string input = "Contents";
+            DimensionType expected = DimensionType.Content;
+            DimensionType actual = ValueParserUtilities.StringToDimensionType(input);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestMethod]
+        public void CustomAliasTest()
+        {
+            string input = "Ranking";
+            PxFileConfiguration conf = PxFileConfiguration.Default;
+            conf.Tokens.VariableTypes.Ordinal = ["Ordinal", "Ranking"];
+
+            DimensionType expected = DimensionType.Ordinal;
+            DimensionType actual = ValueParserUtilities.StringToDimensionType(input, conf);
             Assert.AreEqual(expected, actual);
         }
 

--- a/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
+++ b/Px.Utils.UnitTests/ModelBuilderTests/ValueParserUtilitiesTests/StringToDimensionTypeTests.cs
@@ -1,6 +1,7 @@
 using Px.Utils.ModelBuilders;
 using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.PxFile;
+using System.Globalization;
 
 namespace Px.Utils.UnitTests.ModelBuilderTests.ValueParserUtilitiesTests
 {
@@ -26,13 +27,14 @@ namespace Px.Utils.UnitTests.ModelBuilderTests.ValueParserUtilitiesTests
         }
 
         [TestMethod]
-        public void CustomAliasTest()
+        [DataRow("RANKING", DimensionType.Ordinal)]
+        [DataRow("region", DimensionType.Geographical)]
+        public void CustomAliasTest(string alias, DimensionType expected)
         {
-            string input = "Ranking";
+            string input = alias.ToUpper(CultureInfo.InvariantCulture); // Testing case-insensitivity
             PxFileConfiguration conf = PxFileConfiguration.Default;
-            conf.Tokens.VariableTypes.Mappings["Ranking"] = DimensionType.Ordinal;
+            conf.Tokens.VariableTypes.Mappings[alias] = expected; 
 
-            DimensionType expected = DimensionType.Ordinal;
             DimensionType actual = ValueParserUtilities.StringToDimensionType(input, conf);
             Assert.AreEqual(expected, actual);
         }

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -537,7 +537,7 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
         }
 
         [TestMethod]
-        public void ValidateValueTypesCalledWithStructuredEntryArrayWithKnownDimensionTypeAliasesReturnsWithWarnings()
+        public void ValidateValueContentsCalledWithStructuredEntryArrayWithKnownDimensionTypeAliasesReturnsWithWarnings()
         {
             // Arrange
             ValidationStructuredEntry[] entries = ContentValidationFixtures.STRUCTURED_ENTRY_ARRAY_WITH_KNOWN_DIMENSIONTYPE_ALIASES;

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -3,6 +3,7 @@ using Px.Utils.Validation;
 using Px.Utils.Validation.ContentValidation;
 using Px.Utils.Validation.SyntaxValidation;
 using Px.Utils.PxFile;
+using Px.Utils.Models.Metadata.Enums;
 using System.Text;
 using System.Reflection;
 
@@ -538,32 +539,35 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
         }
 
         [TestMethod]
-        public void ValidateValueContentsCalledWithStructuredEntryArrayWithKnownDimensionTypeAliasesReturnsWithWarnings()
-        {
-            // Arrange
-            ValidationStructuredEntry[] entries = ContentValidationFixtures.STRUCTURED_ENTRY_ARRAY_WITH_KNOWN_DIMENSIONTYPE_ALIASES;
-            ContentValidator validator = new(filename, encoding, entries);
-            // Act
-            foreach (ValidationStructuredEntry entry in entries)
-            {
-                ValidationFeedback? result = ContentValidator.ValidateValueContents(
-                    entry,
-                    validator
-                    );
-                // Assert
-                Assert.IsNotNull(result);
-                Assert.HasCount(1, result);
-                Assert.AreEqual(ValidationFeedbackRule.InvalidValueFound, result.First().Key.Rule);
-                Assert.AreEqual(ValidationFeedbackLevel.Warning, result.First().Key.Level);
-            }
-        }
-
-        [TestMethod]
-        public void ValidateValueContentsCalledWithConfiguredDimensionTypeAliasReturnsWithWarning()
+        public void ValidateValueContentsCalledWithDimensionTypeEnumValueReturnsWithoutFeedback()
         {
             // Arrange
             PxFileConfiguration conf = PxFileConfiguration.Default;
-            conf.Tokens.VariableTypes.Ordinal = ["Ordinal", "Ranking"];
+
+            ValidationStructuredEntry entry = new(
+                filename,
+                new ValidationStructuredEntryKey("VARIABLE-TYPE", "fi", "foo"),
+                "Content",
+                0,
+                [],
+                0,
+                Utils.Validation.ValueType.StringValue);
+
+            ContentValidator validator = new(filename, encoding, [entry], conf: conf);
+
+            // Act
+            ValidationFeedback? result = ContentValidator.ValidateValueContents(entry, validator);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void ValidateValueContentsCalledWithCustomDimensionTypeValueReturnsWithoutFeedback()
+        {
+            // Arrange
+            PxFileConfiguration conf = PxFileConfiguration.Default;
+            conf.Tokens.VariableTypes.Mappings["Ranking"] = DimensionType.Ordinal;
 
             ValidationStructuredEntry entry = new(
                 filename,
@@ -572,7 +576,31 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
                 0,
                 [],
                 0,
-                Px.Utils.Validation.ValueType.StringValue);
+                Utils.Validation.ValueType.StringValue);
+
+            ContentValidator validator = new(filename, encoding, [entry], conf: conf);
+
+            // Act
+            ValidationFeedback? result = ContentValidator.ValidateValueContents(entry, validator);
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public void ValidateValueContentsCalledWithUnknownDimensionTypeValueReturnsWithoutFeedback()
+        {
+            // Arrange
+            PxFileConfiguration conf = PxFileConfiguration.Default;
+
+            ValidationStructuredEntry entry = new(
+                filename,
+                new ValidationStructuredEntryKey("VARIABLE-TYPE", "fi", "foo"),
+                "Ranking",
+                0,
+                [],
+                0,
+                Utils.Validation.ValueType.StringValue);
 
             ContentValidator validator = new(filename, encoding, [entry], conf: conf);
 
@@ -583,7 +611,6 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
             Assert.IsNotNull(result);
             Assert.HasCount(1, result);
             Assert.AreEqual(ValidationFeedbackRule.InvalidValueFound, result.First().Key.Rule);
-            Assert.AreEqual(ValidationFeedbackLevel.Warning, result.First().Key.Level);
         }
 
         [TestMethod]

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -557,7 +557,6 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
                 0,
                 Utils.Validation.ValueType.StringValue);
 
-
             ContentValidator validator = new(filename, encoding, [entry], conf: conf);
 
             // Act

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -568,7 +568,7 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
         }
 
         [TestMethod]
-        public void ValidateValueContentsCalledWithUnknownDimensionTypeValueReturnsWithoutFeedback()
+        public void ValidateValueContentsCalledWithUnknownDimensionTypeValueReturnsWithError()
         {
             // Arrange
             PxFileConfiguration conf = PxFileConfiguration.Default;
@@ -591,6 +591,7 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
             Assert.IsNotNull(result);
             Assert.HasCount(1, result);
             Assert.AreEqual(ValidationFeedbackRule.InvalidValueFound, result.First().Key.Rule);
+            Assert.AreEqual(ValidationFeedbackLevel.Error, result.First().Key.Level);
         }
 
         [TestMethod]

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -6,6 +6,7 @@ using Px.Utils.PxFile;
 using Px.Utils.Models.Metadata.Enums;
 using System.Text;
 using System.Reflection;
+using System.Globalization;
 
 namespace Px.Utils.UnitTests.Validation.ContentValidationTests
 {
@@ -539,20 +540,23 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
         }
 
         [TestMethod]
-        public void ValidateValueContentsCalledWithCustomDimensionTypeValueReturnsWithoutFeedback()
+        [DataRow("ranking", DimensionType.Ordinal)]
+        [DataRow("REGION", DimensionType.Geographical)]
+        public void ValidateValueContentsCalledWithCustomDimensionTypesValueReturnsWithoutFeedback(string alias, DimensionType dimensionType)
         {
             // Arrange
             PxFileConfiguration conf = PxFileConfiguration.Default;
-            conf.Tokens.VariableTypes.Mappings["Ranking"] = DimensionType.Ordinal;
+            conf.Tokens.VariableTypes.Mappings[alias] = dimensionType;
 
             ValidationStructuredEntry entry = new(
                 filename,
                 new ValidationStructuredEntryKey("VARIABLE-TYPE", "fi", "foo"),
-                "Ranking",
+                alias.ToUpper(CultureInfo.InvariantCulture), // The value is converted to upper case to verify case insensitivity of the dimension type matching
                 0,
                 [],
                 0,
                 Utils.Validation.ValueType.StringValue);
+
 
             ContentValidator validator = new(filename, encoding, [entry], conf: conf);
 

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -537,6 +537,27 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
         }
 
         [TestMethod]
+        public void ValidateValueTypesCalledWithStructuredEntryArrayWithKnownDimensionTypeAliasesReturnsWithWarnings()
+        {
+            // Arrange
+            ValidationStructuredEntry[] entries = ContentValidationFixtures.STRUCTURED_ENTRY_ARRAY_WITH_KNOWN_DIMENSIONTYPE_ALIASES;
+            ContentValidator validator = new(filename, encoding, entries);
+            // Act
+            foreach (ValidationStructuredEntry entry in entries)
+            {
+                ValidationFeedback? result = ContentValidator.ValidateValueContents(
+                    entry,
+                    validator
+                    );
+                // Assert
+                Assert.IsNotNull(result);
+                Assert.HasCount(1, result);
+                Assert.AreEqual(ValidationFeedbackRule.InvalidValueFound, result.First().Key.Rule);
+                Assert.AreEqual(ValidationFeedbackLevel.Warning, result.First().Key.Level);
+            }
+        }
+
+        [TestMethod]
         public void ValidateValueAmountsCalledWithUnmatchingAmountOfElementsReturnsWithError()
         {
             // Arrange

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -539,30 +539,6 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
         }
 
         [TestMethod]
-        public void ValidateValueContentsCalledWithDimensionTypeEnumValueReturnsWithoutFeedback()
-        {
-            // Arrange
-            PxFileConfiguration conf = PxFileConfiguration.Default;
-
-            ValidationStructuredEntry entry = new(
-                filename,
-                new ValidationStructuredEntryKey("VARIABLE-TYPE", "fi", "foo"),
-                "Content",
-                0,
-                [],
-                0,
-                Utils.Validation.ValueType.StringValue);
-
-            ContentValidator validator = new(filename, encoding, [entry], conf: conf);
-
-            // Act
-            ValidationFeedback? result = ContentValidator.ValidateValueContents(entry, validator);
-
-            // Assert
-            Assert.IsNull(result);
-        }
-
-        [TestMethod]
         public void ValidateValueContentsCalledWithCustomDimensionTypeValueReturnsWithoutFeedback()
         {
             // Arrange

--- a/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
+++ b/Px.Utils.UnitTests/Validation/ContentValidationTests/ContentValidationTests.cs
@@ -2,6 +2,7 @@ using Px.Utils.UnitTests.Validation.Fixtures;
 using Px.Utils.Validation;
 using Px.Utils.Validation.ContentValidation;
 using Px.Utils.Validation.SyntaxValidation;
+using Px.Utils.PxFile;
 using System.Text;
 using System.Reflection;
 
@@ -555,6 +556,34 @@ namespace Px.Utils.UnitTests.Validation.ContentValidationTests
                 Assert.AreEqual(ValidationFeedbackRule.InvalidValueFound, result.First().Key.Rule);
                 Assert.AreEqual(ValidationFeedbackLevel.Warning, result.First().Key.Level);
             }
+        }
+
+        [TestMethod]
+        public void ValidateValueContentsCalledWithConfiguredDimensionTypeAliasReturnsWithWarning()
+        {
+            // Arrange
+            PxFileConfiguration conf = PxFileConfiguration.Default;
+            conf.Tokens.VariableTypes.Ordinal = ["Ordinal", "Ranking"];
+
+            ValidationStructuredEntry entry = new(
+                filename,
+                new ValidationStructuredEntryKey("VARIABLE-TYPE", "fi", "foo"),
+                "Ranking",
+                0,
+                [],
+                0,
+                Px.Utils.Validation.ValueType.StringValue);
+
+            ContentValidator validator = new(filename, encoding, [entry], conf: conf);
+
+            // Act
+            ValidationFeedback? result = ContentValidator.ValidateValueContents(entry, validator);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.HasCount(1, result);
+            Assert.AreEqual(ValidationFeedbackRule.InvalidValueFound, result.First().Key.Rule);
+            Assert.AreEqual(ValidationFeedbackLevel.Warning, result.First().Key.Level);
         }
 
         [TestMethod]

--- a/Px.Utils.UnitTests/Validation/DatabaseValidation/DatabaseValidatorTests.cs
+++ b/Px.Utils.UnitTests/Validation/DatabaseValidation/DatabaseValidatorTests.cs
@@ -161,7 +161,7 @@ namespace Px.Utils.UnitTests.Validation.DatabaseValidation
             IDatabaseValidator[] customValidators =
                 [
                     new MockCustomDatabaseValidator()
-                    ];
+                ];
             DatabaseValidator validator = new(
                 "database_invalid", 
                 customPxFileValidators: customValidators,

--- a/Px.Utils.UnitTests/Validation/Fixtures/ContentValidationFixtures.cs
+++ b/Px.Utils.UnitTests/Validation/Fixtures/ContentValidationFixtures.cs
@@ -306,7 +306,7 @@ namespace Px.Utils.UnitTests.Validation.Fixtures
         private static readonly ValidationStructuredEntry variableTypeBarEntry =
             new(filename,
                 new ValidationStructuredEntryKey("VARIABLE-TYPE", null, "bar"),
-                "Content",
+                "Contents",
                 23,
                 [],
                 13,
@@ -428,9 +428,6 @@ namespace Px.Utils.UnitTests.Validation.Fixtures
                 [],
                 17,
                 Utils.Validation.ValueType.StringValue);
-
-        private static readonly ValidationStructuredEntryKey dimensionTypeEntryKey =
-                new ("VARIABLE-TYPE", "fi", "foo");
 
         internal static ValidationStructuredEntry[] MINIMAL_STRUCTURED_ENTRY_ARRAY =>
         [

--- a/Px.Utils.UnitTests/Validation/Fixtures/ContentValidationFixtures.cs
+++ b/Px.Utils.UnitTests/Validation/Fixtures/ContentValidationFixtures.cs
@@ -429,6 +429,9 @@ namespace Px.Utils.UnitTests.Validation.Fixtures
                 17,
                 Utils.Validation.ValueType.StringValue);
 
+        private static readonly ValidationStructuredEntryKey dimensionTypeEntryKey =
+                new ("VARIABLE-TYPE", "fi", "foo");
+
         internal static ValidationStructuredEntry[] MINIMAL_STRUCTURED_ENTRY_ARRAY =>
         [
             charsetEntry,
@@ -750,6 +753,12 @@ namespace Px.Utils.UnitTests.Validation.Fixtures
                     variableTypeBarEntry.LineChangeIndexes,
                     variableTypeBarEntry.ValueStartIndex,
                     Utils.Validation.ValueType.StringValue),
+            ];
+
+        internal static ValidationStructuredEntry[] STRUCTURED_ENTRY_ARRAY_WITH_KNOWN_DIMENSIONTYPE_ALIASES =>
+            [
+                new ValidationStructuredEntry(filename, dimensionTypeEntryKey, "Contents", 0, [], 0, Utils.Validation.ValueType.StringValue),
+                new ValidationStructuredEntry(filename, dimensionTypeEntryKey, "Region", 1, [], 0, Utils.Validation.ValueType.StringValue),
             ];
 
         internal static ValidationStructuredEntry StructuredEntryWithUnmatchingAmountOfElements =>

--- a/Px.Utils.UnitTests/Validation/Fixtures/ContentValidationFixtures.cs
+++ b/Px.Utils.UnitTests/Validation/Fixtures/ContentValidationFixtures.cs
@@ -755,12 +755,6 @@ namespace Px.Utils.UnitTests.Validation.Fixtures
                     Utils.Validation.ValueType.StringValue),
             ];
 
-        internal static ValidationStructuredEntry[] STRUCTURED_ENTRY_ARRAY_WITH_KNOWN_DIMENSIONTYPE_ALIASES =>
-            [
-                new ValidationStructuredEntry(filename, dimensionTypeEntryKey, "Contents", 0, [], 0, Utils.Validation.ValueType.StringValue),
-                new ValidationStructuredEntry(filename, dimensionTypeEntryKey, "Region", 1, [], 0, Utils.Validation.ValueType.StringValue),
-            ];
-
         internal static ValidationStructuredEntry StructuredEntryWithUnmatchingAmountOfElements =>
             new(filename,
                 codesBarEntry.Key,

--- a/Px.Utils.UnitTests/Validation/Fixtures/PxFileFixtures.cs
+++ b/Px.Utils.UnitTests/Validation/Fixtures/PxFileFixtures.cs
@@ -1,4 +1,4 @@
-﻿namespace Px.Utils.UnitTests.Validation.Fixtures
+namespace Px.Utils.UnitTests.Validation.Fixtures
 {
     internal static class PxFileFixtures
     {
@@ -22,7 +22,7 @@
             "\r\nCODES(\"Vuosi\")=\"2015\",\"2016\",\"2017\",\"2018\",\"2019\",\"2020\",\"2021\",\"2022\",\"2023\",\"2024\";" +
             "\r\nCODES(\"Tiedot\")=\"code-foo-val-a\",\"code-foo-val-b\";" +
             "\r\nVARIABLE-TYPE(\"Vuosi\")=\"Time\";" +
-            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Content\";" +
+            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Contents\";" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-a\")=1;" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-b\")=1;" +
             "\r\nLAST-UPDATED(\"Tiedot\",\"foo-val-a\")=\"20231101 08:00\";" +
@@ -64,7 +64,7 @@
             "\r\nCODES(\"Vuosi\")=\"2015\",\"2016\",\"2017\",\"2018\",\"2019\",\"2020\",\"2021\",\"2022\",\"2023\",\"2024\";" +
             "\r\nCODES(\"Tiedot\")=\"code-foo-val-a\",\"code-foo-val-b\";" +
             "\r\nVARIABLE-TYPE(\"Vuosi\")=\"Time\";" +
-            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Content\";" +
+            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Contents\";" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-a\")=1;" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-b\")=1;" +
             "\r\nLAST-UPDATED(\"Tiedot\",\"foo-val-a\")=\"20231101 08:00\";" +
@@ -94,7 +94,7 @@
             "\r\nCODES(\"Vuosi\")=\"2015\",\"2016\",\"2017\",\"2018\",\"2019\",\"2020\",\"2021\",\"2022\",\"2023\",\"2024\";" +
             "\r\nCODES(\"Tiedot\")=\"code-foo-val-a\",\"code-foo-val-b\";" +
             "\r\nVARIABLE-TYPE(\"Vuosi\")=\"Time\";" +
-            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Content\";" +
+            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Contents\";" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-a\")=1;" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-b\")=1;" +
             "\r\nLAST-UPDATED(\"Tiedot\",\"foo-val-a\")=\"20231101 08:00\";" +
@@ -135,7 +135,7 @@
             "\r\nCODES(\"Vuosi\")=\"2015\",\"2016\",\"2017\",\"2018\",\"2019\",\"2020\",\"2021\",\"2022\",\"2023\",\"2024\";" +
             "\r\nCODES(\"Tiedot\")=\"code-foo-val-a\",\"code-foo-val-b\";" +
             "\r\nVARIABLE-TYPE(\"Vuosi\")=\"Time\";" +
-            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Content\";" +
+            "\r\nVARIABLE-TYPE(\"Tiedot\")=\"Contents\";" +
             "\r\nPRECISION(\"Tiedot\",\"foo-val-a\")=1;" +
             "\r\nLAST-UPDATED(\"Tiedot\",\"foo-val-a\")=\"20231101 08:00\";" +
             "\r\nUNITS(\"Tiedot\",\"foo-val-a\")=\"kpl\";" +

--- a/Px.Utils.sln
+++ b/Px.Utils.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.8.34408.163
+# Visual Studio Version 18
+VisualStudioVersion = 18.5.11709.299 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Px.Utils", "Px.Utils\Px.Utils.csproj", "{D94934AF-6B41-4C66-818A-C4C33230E9DD}"
 EndProject
@@ -36,6 +36,18 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Px.Utils.TestingApp", "Px.U
 		{D94934AF-6B41-4C66-818A-C4C33230E9DD} = {D94934AF-6B41-4C66-818A-C4C33230E9DD}
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "architecture", "architecture", "{BFA8E05B-EBD8-4085-B765-EAED69DD0874}"
+	ProjectSection(SolutionItems) = preProject
+		docs\architecture.md = docs\architecture.md
+		docs\architecture.models.md = docs\architecture.models.md
+		docs\architecture.operations.md = docs\architecture.operations.md
+		docs\architecture.overview.md = docs\architecture.overview.md
+		docs\architecture.readers.md = docs\architecture.readers.md
+		docs\architecture.serializers.md = docs\architecture.serializers.md
+		docs\architecture.testing.md = docs\architecture.testing.md
+		docs\architecture.validation.md = docs\architecture.validation.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +72,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{EB4119B8-8292-418A-9CD3-2905DA67B889} = {BC1C9772-9B8F-49A7-A8F3-09E3A94789ED}
+		{BFA8E05B-EBD8-4085-B765-EAED69DD0874} = {42DFE3AF-7507-415A-806B-99B74519BF97}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B1F81A3B-9FF5-4557-8A5A-A9519C42C2B2}

--- a/Px.Utils.sln
+++ b/Px.Utils.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 18
-VisualStudioVersion = 18.5.11709.299 stable
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Px.Utils", "Px.Utils\Px.Utils.csproj", "{D94934AF-6B41-4C66-818A-C4C33230E9DD}"
 EndProject

--- a/Px.Utils/ModelBuilders/ValueParserUtilities.cs
+++ b/Px.Utils/ModelBuilders/ValueParserUtilities.cs
@@ -102,6 +102,7 @@ namespace Px.Utils.ModelBuilders
         /// <summary>
         /// Parses a string into a <see cref="DimensionType"/> enumeration value.
         /// This method maps the input string to a <see cref="DimensionType"/> enumeration value based on the provided or default PxFileConfiguration configuration.
+        /// The first configured token for a dimension type is treated as the primary value and any additional configured tokens are treated as aliases.
         /// If the input string does not map to a known <see cref="DimensionType"/>, the method returns <see cref="DimensionType.Unknown"/>.
         /// </summary>
         /// <param name="input">The string to parse into a <see cref="DimensionType"/> enumeration value.</param>
@@ -110,22 +111,40 @@ namespace Px.Utils.ModelBuilders
         public static DimensionType StringToDimensionType(string input, PxFileConfiguration? conf = null)
         {
             conf ??= PxFileConfiguration.Default;
-            Dictionary<string, DimensionType> map = new()
-            {
-                {conf.Tokens.VariableTypes.Content, DimensionType.Content},
-                {conf.Tokens.VariableTypes.Contents, DimensionType.Content}, // Known alias for content dimension type
-                {conf.Tokens.VariableTypes.Time, DimensionType.Time},
-                {conf.Tokens.VariableTypes.Ordinal, DimensionType.Ordinal},
-                {conf.Tokens.VariableTypes.Nominal, DimensionType.Nominal},
-                {conf.Tokens.VariableTypes.Geographical, DimensionType.Geographical},
-                {conf.Tokens.VariableTypes.Region, DimensionType.Geographical}, // Known alias for geographical dimension type
-                {conf.Tokens.VariableTypes.Other, DimensionType.Other},
-                {conf.Tokens.VariableTypes.Unknown, DimensionType.Unknown}
-            };
+            Dictionary<string, DimensionType> map = GetDimensionTypeTokenMap(conf);
 
             string cleanString = input.CleanStringDelimeters(conf.Symbols.Value.StringDelimeter);
-            if (map.TryGetValue(cleanString, out DimensionType value)) return value;
-            else return DimensionType.Unknown;
+            if (map.TryGetValue(cleanString, out DimensionType value))
+            {
+                return value;
+            }
+
+            return DimensionType.Unknown;
+        }
+
+        private static Dictionary<string, DimensionType> GetDimensionTypeTokenMap(PxFileConfiguration conf)
+        {
+            Dictionary<string, DimensionType> map = [];
+            Dictionary<DimensionType, string[]> tokensByType = new()
+            {
+                { DimensionType.Content, conf.Tokens.VariableTypes.Content },
+                { DimensionType.Time, conf.Tokens.VariableTypes.Time },
+                { DimensionType.Ordinal, conf.Tokens.VariableTypes.Ordinal },
+                { DimensionType.Nominal, conf.Tokens.VariableTypes.Nominal },
+                { DimensionType.Geographical, conf.Tokens.VariableTypes.Geographical },
+                { DimensionType.Other, conf.Tokens.VariableTypes.Other },
+                { DimensionType.Unknown, conf.Tokens.VariableTypes.Unknown }
+            };
+
+            foreach (KeyValuePair<DimensionType, string[]> tokenSet in tokensByType)
+            {
+                foreach (string token in tokenSet.Value)
+                {
+                    map[token] = tokenSet.Key;
+                }
+            }
+
+            return map;
         }
     }
 }

--- a/Px.Utils/ModelBuilders/ValueParserUtilities.cs
+++ b/Px.Utils/ModelBuilders/ValueParserUtilities.cs
@@ -102,7 +102,7 @@ namespace Px.Utils.ModelBuilders
         /// <summary>
         /// Parses a string into a <see cref="DimensionType"/> enumeration value.
         /// This method maps the input string to a <see cref="DimensionType"/> enumeration value based on the provided or default PxFileConfiguration configuration.
-        /// The first configured token for a dimension type is treated as the primary value and any additional configured tokens are treated as aliases.
+        /// Mapping is done using the configured variable type mappings.
         /// If the input string does not map to a known <see cref="DimensionType"/>, the method returns <see cref="DimensionType.Unknown"/>.
         /// </summary>
         /// <param name="input">The string to parse into a <see cref="DimensionType"/> enumeration value.</param>
@@ -111,40 +111,14 @@ namespace Px.Utils.ModelBuilders
         public static DimensionType StringToDimensionType(string input, PxFileConfiguration? conf = null)
         {
             conf ??= PxFileConfiguration.Default;
-            Dictionary<string, DimensionType> map = GetDimensionTypeTokenMap(conf);
 
             string cleanString = input.CleanStringDelimeters(conf.Symbols.Value.StringDelimeter);
-            if (map.TryGetValue(cleanString, out DimensionType value))
+            if (conf.Tokens.VariableTypes.Mappings.TryGetValue(cleanString, out DimensionType value))
             {
                 return value;
             }
 
             return DimensionType.Unknown;
-        }
-
-        private static Dictionary<string, DimensionType> GetDimensionTypeTokenMap(PxFileConfiguration conf)
-        {
-            Dictionary<string, DimensionType> map = [];
-            Dictionary<DimensionType, string[]> tokensByType = new()
-            {
-                { DimensionType.Content, conf.Tokens.VariableTypes.Content },
-                { DimensionType.Time, conf.Tokens.VariableTypes.Time },
-                { DimensionType.Ordinal, conf.Tokens.VariableTypes.Ordinal },
-                { DimensionType.Nominal, conf.Tokens.VariableTypes.Nominal },
-                { DimensionType.Geographical, conf.Tokens.VariableTypes.Geographical },
-                { DimensionType.Other, conf.Tokens.VariableTypes.Other },
-                { DimensionType.Unknown, conf.Tokens.VariableTypes.Unknown }
-            };
-
-            foreach (KeyValuePair<DimensionType, string[]> tokenSet in tokensByType)
-            {
-                foreach (string token in tokenSet.Value)
-                {
-                    map[token] = tokenSet.Key;
-                }
-            }
-
-            return map;
         }
     }
 }

--- a/Px.Utils/ModelBuilders/ValueParserUtilities.cs
+++ b/Px.Utils/ModelBuilders/ValueParserUtilities.cs
@@ -1,4 +1,4 @@
-﻿using Px.Utils.Models.Metadata.Enums;
+using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.Models.Metadata.ExtensionMethods;
 using Px.Utils.PxFile;
 
@@ -113,10 +113,12 @@ namespace Px.Utils.ModelBuilders
             Dictionary<string, DimensionType> map = new()
             {
                 {conf.Tokens.VariableTypes.Content, DimensionType.Content},
+                {conf.Tokens.VariableTypes.Contents, DimensionType.Content}, // Known alias for content dimension type
                 {conf.Tokens.VariableTypes.Time, DimensionType.Time},
                 {conf.Tokens.VariableTypes.Ordinal, DimensionType.Ordinal},
                 {conf.Tokens.VariableTypes.Nominal, DimensionType.Nominal},
                 {conf.Tokens.VariableTypes.Geographical, DimensionType.Geographical},
+                {conf.Tokens.VariableTypes.Region, DimensionType.Geographical}, // Known alias for geographical dimension type
                 {conf.Tokens.VariableTypes.Other, DimensionType.Other},
                 {conf.Tokens.VariableTypes.Unknown, DimensionType.Unknown}
             };

--- a/Px.Utils/ModelBuilders/ValueParserUtilities.cs
+++ b/Px.Utils/ModelBuilders/ValueParserUtilities.cs
@@ -1,6 +1,7 @@
 using Px.Utils.Models.Metadata.Enums;
 using Px.Utils.Models.Metadata.ExtensionMethods;
 using Px.Utils.PxFile;
+using System.Globalization;
 
 namespace Px.Utils.ModelBuilders
 {

--- a/Px.Utils/Px.Utils.csproj
+++ b/Px.Utils/Px.Utils.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<PackageId>Px.Utils</PackageId>
-	<Version>1.4.1</Version>
+	<Version>1.5.0</Version>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/Px.Utils/PxFile/PxFileConfiguration.cs
+++ b/Px.Utils/PxFile/PxFileConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using Px.Utils.Models.Metadata.Enums;
+using Px.Utils.Models.Metadata.Enums;
 
 namespace Px.Utils.PxFile
 {
@@ -110,19 +110,23 @@ namespace Px.Utils.PxFile
             public class VariableTypeTokens
             {
                 private const string CONTENT = "Content";
+                private const string CONTENTS = "Contents";
                 private const string TIME = "Time";
                 private const string ORDINAL = "Ordinal";
                 private const string NOMINAL = "Nominal";
                 private const string GEOGRAPHICAL = "Geographical";
+                private const string REGION = "Region";
                 private const string OTHER = "Other";
                 private const string UNKNOWN = "Unknown";
                 private const string CLASSIFICATORY = "Classificatory";
 
                 public string Content { get; set; } = CONTENT;
+                public string Contents { get; set; } = CONTENTS;
                 public string Time { get; set; } = TIME;
                 public string Ordinal { get; set; } = ORDINAL;
                 public string Nominal { get; set; } = NOMINAL;
                 public string Geographical { get; set; } = GEOGRAPHICAL;
+                public string Region { get; set; } = REGION;
                 public string Other { get; set; } = OTHER;
                 public string Unknown { get; set; } = UNKNOWN;
                 public string Classificatory { get; set; } = CLASSIFICATORY;

--- a/Px.Utils/PxFile/PxFileConfiguration.cs
+++ b/Px.Utils/PxFile/PxFileConfiguration.cs
@@ -107,29 +107,31 @@ namespace Px.Utils.PxFile
                 public static TimeValue DefaultTimeValue => new();
             }
 
+            /// <summary>
+            /// Defines accepted tokens for parsing and validating dimension types.
+            /// The first token in each array is treated as the primary value, while additional tokens are treated as aliases.
+            /// </summary>
             public class VariableTypeTokens
             {
                 private const string CONTENT = "Content";
-                private const string CONTENTS = "Contents";
+                private const string CONTENTS_ALIAS = "Contents";
                 private const string TIME = "Time";
                 private const string ORDINAL = "Ordinal";
                 private const string NOMINAL = "Nominal";
                 private const string GEOGRAPHICAL = "Geographical";
-                private const string REGION = "Region";
+                private const string REGION_ALIAS = "Region";
                 private const string OTHER = "Other";
                 private const string UNKNOWN = "Unknown";
                 private const string CLASSIFICATORY = "Classificatory";
 
-                public string Content { get; set; } = CONTENT;
-                public string Contents { get; set; } = CONTENTS;
-                public string Time { get; set; } = TIME;
-                public string Ordinal { get; set; } = ORDINAL;
-                public string Nominal { get; set; } = NOMINAL;
-                public string Geographical { get; set; } = GEOGRAPHICAL;
-                public string Region { get; set; } = REGION;
-                public string Other { get; set; } = OTHER;
-                public string Unknown { get; set; } = UNKNOWN;
-                public string Classificatory { get; set; } = CLASSIFICATORY;
+                public string[] Content { get; set; } = [CONTENT, CONTENTS_ALIAS];
+                public string[] Time { get; set; } = [TIME];
+                public string[] Ordinal { get; set; } = [ORDINAL];
+                public string[] Nominal { get; set; } = [NOMINAL];
+                public string[] Geographical { get; set; } = [GEOGRAPHICAL, REGION_ALIAS];
+                public string[] Other { get; set; } = [OTHER];
+                public string[] Unknown { get; set; } = [UNKNOWN];
+                public string[] Classificatory { get; set; } = [CLASSIFICATORY];
 
                 private VariableTypeTokens() { }
 

--- a/Px.Utils/PxFile/PxFileConfiguration.cs
+++ b/Px.Utils/PxFile/PxFileConfiguration.cs
@@ -108,33 +108,28 @@ namespace Px.Utils.PxFile
             }
 
             /// <summary>
-            /// Defines accepted tokens for parsing and validating dimension types.
-            /// The first token in each array is treated as the primary value, while additional tokens are treated as aliases.
+            /// Defines accepted tokens for parsing and validating dimension types using an expandable dictionary string to <see cref="DimensionType"/>.
             /// </summary>
             public class VariableTypeTokens
             {
-                private const string CONTENT = "Content";
-                private const string CONTENTS_ALIAS = "Contents";
-                private const string TIME = "Time";
-                private const string ORDINAL = "Ordinal";
-                private const string NOMINAL = "Nominal";
-                private const string GEOGRAPHICAL = "Geographical";
-                private const string REGION_ALIAS = "Region";
-                private const string OTHER = "Other";
-                private const string UNKNOWN = "Unknown";
-                private const string CLASSIFICATORY = "Classificatory";
-
-                public string[] Content { get; set; } = [CONTENT, CONTENTS_ALIAS];
-                public string[] Time { get; set; } = [TIME];
-                public string[] Ordinal { get; set; } = [ORDINAL];
-                public string[] Nominal { get; set; } = [NOMINAL];
-                public string[] Geographical { get; set; } = [GEOGRAPHICAL, REGION_ALIAS];
-                public string[] Other { get; set; } = [OTHER];
-                public string[] Unknown { get; set; } = [UNKNOWN];
-                public string[] Classificatory { get; set; } = [CLASSIFICATORY];
+                /// <summary>
+                /// Gets or sets the expandable dictionary mapping string tokens to dimension types.
+                /// </summary>
+                public Dictionary<string, DimensionType> Mappings { get; set; } = new(StringComparer.Ordinal)
+                {
+                    { "Time", DimensionType.Time },
+                    { "Contents", DimensionType.Content },
+                    { "Geographical", DimensionType.Geographical },
+                    { "Ordinal", DimensionType.Ordinal },
+                    { "Nominal", DimensionType.Nominal },
+                    { "Other", DimensionType.Other },
+                };
 
                 private VariableTypeTokens() { }
 
+                /// <summary>
+                /// Gets the default variable type tokens configuration.
+                /// </summary>
                 public static VariableTypeTokens DefaultVariableTypeTokens => new();
             }
 

--- a/Px.Utils/PxFile/PxFileConfiguration.cs
+++ b/Px.Utils/PxFile/PxFileConfiguration.cs
@@ -115,7 +115,7 @@ namespace Px.Utils.PxFile
                 /// <summary>
                 /// Gets or sets the expandable dictionary mapping string tokens to dimension types.
                 /// </summary>
-                public Dictionary<string, DimensionType> Mappings { get; set; } = new(StringComparer.Ordinal)
+                public Dictionary<string, DimensionType> Mappings { get; set; } = new(StringComparer.OrdinalIgnoreCase)
                 {
                     { "Time", DimensionType.Time },
                     { "Contents", DimensionType.Content },

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -1,5 +1,5 @@
-using Px.Utils.PxFile;
 using Px.Utils.Validation.SyntaxValidation;
+using Px.Utils.Models.Metadata.Enums;
 using System.Globalization;
 
 namespace Px.Utils.Validation.ContentValidation
@@ -338,7 +338,17 @@ namespace Px.Utils.Validation.ContentValidation
             }
             else if (keyword == validator.Conf.Tokens.KeyWords.DimensionType)
             {
-                (recommendedValueContents, knownAliases) = BuildAllowedDimensionTypes(validator.Conf);
+                if (Enum.TryParse<DimensionType>(value, out DimensionType enumType) && value == enumType.ToString())
+                {
+                    return null;
+                }
+
+                if (validator.Conf.Tokens.VariableTypes.Mappings.TryGetValue(value, out DimensionType mappedType))
+                {
+                    return null;
+                }
+
+                return CreateInvalidValueFeedback(entry, validator, ValidationFeedbackLevel.Error);
             }
             else if (keyword == validator.Conf.Tokens.KeyWords.ContentVariableIdentifier)
             {
@@ -471,43 +481,6 @@ namespace Px.Utils.Validation.ContentValidation
                 return new(feedback);
             }
             return null;
-        }
-
-        private static (string[] RecommendedValueContents, string[] KnownAliases) BuildAllowedDimensionTypes(PxFileConfiguration conf)
-        {
-            List<string> primaryDimensionTypes = [];
-            List<string> aliasDimensionTypes = [];
-            string[][] dimensionTypeTokenSets =
-            [
-                conf.Tokens.VariableTypes.Content,
-                conf.Tokens.VariableTypes.Time,
-                conf.Tokens.VariableTypes.Ordinal,
-                conf.Tokens.VariableTypes.Nominal,
-                conf.Tokens.VariableTypes.Geographical,
-                conf.Tokens.VariableTypes.Other,
-                conf.Tokens.VariableTypes.Unknown,
-                conf.Tokens.VariableTypes.Classificatory
-            ];
-
-            foreach (string[] tokenSet in dimensionTypeTokenSets)
-            {
-                if (tokenSet.Length == 0 || string.IsNullOrWhiteSpace(tokenSet[0]))
-                {
-                    continue;
-                }
-
-                primaryDimensionTypes.Add(tokenSet[0]);
-
-                for (int i = 1; i < tokenSet.Length; i++)
-                {
-                    if (!string.IsNullOrWhiteSpace(tokenSet[i]))
-                    {
-                        aliasDimensionTypes.Add(tokenSet[i]);
-                    }
-                }
-            }
-
-            return ([.. primaryDimensionTypes], [.. aliasDimensionTypes]);
         }
     }
 }

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -1,6 +1,5 @@
 using Px.Utils.PxFile;
 using Px.Utils.Validation.SyntaxValidation;
-using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 
 namespace Px.Utils.Validation.ContentValidation

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -1,5 +1,6 @@
 using Px.Utils.PxFile;
 using Px.Utils.Validation.SyntaxValidation;
+using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 
 namespace Px.Utils.Validation.ContentValidation
@@ -318,69 +319,79 @@ namespace Px.Utils.Validation.ContentValidation
         /// </summary>
         /// <param name="entry">Entry in the Px file metadata. Represented by a <see cref="ValidationStructuredEntry"/> object</param>
         /// <param name="validator"><see cref="ContentValidator"/> object that stores information that is gathered during the validation process</param>
-        /// <returns>Key value pair containing information about the rule violation is returned if an unexpected value is detected</returns>
+        /// <returns>Key value pair containing information about the rule violation is returned if an unexpected or unrecommended value is detected from the entry</returns>
         public static ValidationFeedback? ValidateValueContents(ValidationStructuredEntry entry, ContentValidator validator)
         {
-            string[] allowedCharsets = ["ANSI", "Unicode"];
-
-            HashSet<string> primaryDimensionTypes = GetPrimaryDimensionTypeTokens(validator.Conf);
-            HashSet<string> aliasDimensionTypes = GetAliasDimensionTypeTokens(validator.Conf);
-
+            string[] recommendedValueContents = [];
+            string[] knownAliases = [];
+            StringComparer comparer = StringComparer.Ordinal;
+            string keyword = entry.Key.Keyword;
             string value = SyntaxValidationUtilityMethods.CleanString(entry.Value, validator.Conf);
-            if ((entry.Key.Keyword == validator.Conf.Tokens.KeyWords.Charset && !allowedCharsets.Contains(value)) ||
-                (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.CodePage && !value.Equals(validator._encoding.BodyName, StringComparison.OrdinalIgnoreCase)) ||
-                (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && !primaryDimensionTypes.Contains(value) && !aliasDimensionTypes.Contains(value)) ||
-                (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && aliasDimensionTypes.Contains(value)))
+
+            if (keyword == validator.Conf.Tokens.KeyWords.Charset)
             {
-                // Using a known alias dimension type as a value for DimensionType is not invalid but is not recommended, so it is reported as a warning instead of an error
-                ValidationFeedbackLevel level = entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && aliasDimensionTypes.Contains(value)
-                    ? ValidationFeedbackLevel.Warning
-                    : ValidationFeedbackLevel.Error;
-
-                KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
-                    entry.KeyStartLineIndex,
-                    entry.ValueStartIndex,
-                    entry.LineChangeIndexes);
-
-                KeyValuePair<ValidationFeedbackKey, ValidationFeedbackValue> feedback = new(
-                    new(level,
-                        ValidationFeedbackRule.InvalidValueFound),
-                    new(validator._filename,
-                        feedbackIndexes.Key,
-                        feedbackIndexes.Value,
-                        $"{entry.Key.Keyword}: {entry.Value}")
-                );
-
-                return new(feedback);
+                recommendedValueContents = ["ANSI", "Unicode"];
             }
-            else if (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.ContentVariableIdentifier)
+            else if (keyword == validator.Conf.Tokens.KeyWords.CodePage)
+            {
+                recommendedValueContents = [validator._encoding.BodyName];
+                comparer = StringComparer.OrdinalIgnoreCase;
+            }
+            else if (keyword == validator.Conf.Tokens.KeyWords.DimensionType)
+            {
+                (recommendedValueContents, knownAliases) = BuildAllowedDimensionTypes(validator.Conf);
+            }
+            else if (keyword == validator.Conf.Tokens.KeyWords.ContentVariableIdentifier)
             {
                 string defaultLanguage = validator._defaultLanguage ?? string.Empty;
                 string lang = entry.Key.Language ?? defaultLanguage;
-                if (validator._stubDimensionNames is not null && validator._stubDimensionNames.TryGetValue(lang, out string[]? stubValues) && 
-                    !Array.Exists(stubValues, d => d == value) &&
-                (validator._headingDimensionNames is not null && validator._headingDimensionNames.TryGetValue(lang, out string[]? headingValues) && 
-                    !Array.Exists(headingValues, d => d == value)))
+                List<string> dimensionNames = [];
+
+                if (validator._stubDimensionNames is not null && validator._stubDimensionNames.TryGetValue(lang, out string[]? stubValues))
                 {
-                    KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
-                        entry.KeyStartLineIndex,
-                        entry.ValueStartIndex,
-                        entry.LineChangeIndexes);
-
-                    KeyValuePair<ValidationFeedbackKey, ValidationFeedbackValue> feedback = new(
-                        new(ValidationFeedbackLevel.Error,
-                                ValidationFeedbackRule.InvalidValueFound),
-                        new(validator._filename,
-                            feedbackIndexes.Key,
-                            feedbackIndexes.Value,
-                            $"{entry.Key.Keyword}: {entry.Value}")
-                    );
-
-                    return new(feedback);
+                    dimensionNames.AddRange(stubValues);
                 }
+
+                if (validator._headingDimensionNames is not null && validator._headingDimensionNames.TryGetValue(lang, out string[]? headingValues))
+                {
+                    dimensionNames.AddRange(headingValues);
+                }
+
+                recommendedValueContents = [.. dimensionNames];
+            }
+
+            if (recommendedValueContents.Length > 0 && !recommendedValueContents.Contains(value, comparer))
+            {
+                ValidationFeedbackLevel level = knownAliases.Contains(value, comparer)
+                    ? ValidationFeedbackLevel.Warning
+                    : ValidationFeedbackLevel.Error;
+
+                return CreateInvalidValueFeedback(entry, validator, level);
             }
 
             return null;
+        }
+
+        private static ValidationFeedback CreateInvalidValueFeedback(
+            ValidationStructuredEntry entry,
+            ContentValidator validator,
+            ValidationFeedbackLevel level)
+        {
+            KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
+                entry.KeyStartLineIndex,
+                entry.ValueStartIndex,
+                entry.LineChangeIndexes);
+
+            KeyValuePair<ValidationFeedbackKey, ValidationFeedbackValue> feedback = new(
+                new(level,
+                    ValidationFeedbackRule.InvalidValueFound),
+                new(validator._filename,
+                    feedbackIndexes.Key,
+                    feedbackIndexes.Value,
+                    $"{entry.Key.Keyword}: {entry.Value}")
+            );
+
+            return new(feedback);
         }
 
         /// <summary>
@@ -463,29 +474,11 @@ namespace Px.Utils.Validation.ContentValidation
             return null;
         }
 
-        private static HashSet<string> GetPrimaryDimensionTypeTokens(PxFileConfiguration conf)
+        private static (string[] RecommendedValueContents, string[] KnownAliases) BuildAllowedDimensionTypes(PxFileConfiguration conf)
         {
-            IEnumerable<string> primaryTokens = GetDimensionTypeTokenSets(conf)
-                .Select(tokens => tokens.FirstOrDefault())
-                .Where(token => !string.IsNullOrWhiteSpace(token))
-                .Cast<string>();
-
-            return [.. primaryTokens];
-        }
-
-        private static HashSet<string> GetAliasDimensionTypeTokens(PxFileConfiguration conf)
-        {
-            IEnumerable<string> aliasTokens = GetDimensionTypeTokenSets(conf)
-                .Where(tokens => tokens.Length > 1)
-                .SelectMany(tokens => tokens.Skip(1))
-                .Where(token => !string.IsNullOrWhiteSpace(token));
-
-            return [.. aliasTokens];
-        }
-
-        private static IEnumerable<string[]> GetDimensionTypeTokenSets(PxFileConfiguration conf)
-        {
-            return
+            List<string> primaryDimensionTypes = [];
+            List<string> aliasDimensionTypes = [];
+            string[][] dimensionTypeTokenSets =
             [
                 conf.Tokens.VariableTypes.Content,
                 conf.Tokens.VariableTypes.Time,
@@ -496,6 +489,26 @@ namespace Px.Utils.Validation.ContentValidation
                 conf.Tokens.VariableTypes.Unknown,
                 conf.Tokens.VariableTypes.Classificatory
             ];
+
+            foreach (string[] tokenSet in dimensionTypeTokenSets)
+            {
+                if (tokenSet.Length == 0 || string.IsNullOrWhiteSpace(tokenSet[0]))
+                {
+                    continue;
+                }
+
+                primaryDimensionTypes.Add(tokenSet[0]);
+
+                for (int i = 1; i < tokenSet.Length; i++)
+                {
+                    if (!string.IsNullOrWhiteSpace(tokenSet[i]))
+                    {
+                        aliasDimensionTypes.Add(tokenSet[i]);
+                    }
+                }
+            }
+
+            return ([.. primaryDimensionTypes], [.. aliasDimensionTypes]);
         }
     }
 }

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -338,11 +338,6 @@ namespace Px.Utils.Validation.ContentValidation
             }
             else if (keyword == validator.Conf.Tokens.KeyWords.DimensionType)
             {
-                if (Enum.TryParse<DimensionType>(value, out DimensionType enumType) && value == enumType.ToString())
-                {
-                    return null;
-                }
-
                 if (validator.Conf.Tokens.VariableTypes.Mappings.TryGetValue(value, out DimensionType mappedType))
                 {
                     return null;

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -323,7 +323,7 @@ namespace Px.Utils.Validation.ContentValidation
             string[] allowedCharsets = ["ANSI", "Unicode"];
 
             string[] dimensionTypes = [
-                    validator.Conf.Tokens.VariableTypes.Content,
+                validator.Conf.Tokens.VariableTypes.Content,
                 validator.Conf.Tokens.VariableTypes.Time,
                 validator.Conf.Tokens.VariableTypes.Geographical,
                 validator.Conf.Tokens.VariableTypes.Ordinal,
@@ -331,20 +331,30 @@ namespace Px.Utils.Validation.ContentValidation
                 validator.Conf.Tokens.VariableTypes.Other,
                 validator.Conf.Tokens.VariableTypes.Unknown,
                 validator.Conf.Tokens.VariableTypes.Classificatory
-                    ];
+            ];
+
+            string[] knownDimensionTypeAliases = [
+                validator.Conf.Tokens.VariableTypes.Contents,
+                validator.Conf.Tokens.VariableTypes.Region,
+            ];
 
             string value = SyntaxValidationUtilityMethods.CleanString(entry.Value, validator.Conf);
             if ((entry.Key.Keyword == validator.Conf.Tokens.KeyWords.Charset && !allowedCharsets.Contains(value)) ||
                 (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.CodePage && !value.Equals(validator._encoding.BodyName, StringComparison.OrdinalIgnoreCase)) ||
                 (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && !dimensionTypes.Contains(value)))
             {
+                // If the value is included in known aliases, set level to warning instead of error
+                ValidationFeedbackLevel level = entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && knownDimensionTypeAliases.Contains(value) ?
+                        ValidationFeedbackLevel.Warning : 
+                        ValidationFeedbackLevel.Error;
+
                 KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
                     entry.KeyStartLineIndex,
                     entry.ValueStartIndex,
                     entry.LineChangeIndexes);
 
                 KeyValuePair<ValidationFeedbackKey, ValidationFeedbackValue> feedback = new(
-                    new(ValidationFeedbackLevel.Error,
+                    new(level,
                         ValidationFeedbackRule.InvalidValueFound),
                     new(validator._filename,
                         feedbackIndexes.Key,

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -318,32 +318,31 @@ namespace Px.Utils.Validation.ContentValidation
         /// </summary>
         /// <param name="entry">Entry in the Px file metadata. Represented by a <see cref="ValidationStructuredEntry"/> object</param>
         /// <param name="validator"><see cref="ContentValidator"/> object that stores information that is gathered during the validation process</param>
-        /// <returns>Key value pair containing information about the rule violation is returned if an unexpected or unrecommended value is detected from the entry</returns>
+        /// <returns>Key value pair containing information about the rule violation is returned if an unexpected value is detected from the entry</returns>
         public static ValidationFeedback? ValidateValueContents(ValidationStructuredEntry entry, ContentValidator validator)
         {
-            string[] recommendedValueContents = [];
-            string[] knownAliases = [];
+            string[] allowedValueContents = [];
             StringComparer comparer = StringComparer.Ordinal;
             string keyword = entry.Key.Keyword;
             string value = SyntaxValidationUtilityMethods.CleanString(entry.Value, validator.Conf);
 
             if (keyword == validator.Conf.Tokens.KeyWords.Charset)
             {
-                recommendedValueContents = ["ANSI", "Unicode"];
+                allowedValueContents = ["ANSI", "Unicode"];
             }
             else if (keyword == validator.Conf.Tokens.KeyWords.CodePage)
             {
-                recommendedValueContents = [validator._encoding.BodyName];
+                allowedValueContents = [validator._encoding.BodyName];
                 comparer = StringComparer.OrdinalIgnoreCase;
             }
             else if (keyword == validator.Conf.Tokens.KeyWords.DimensionType)
             {
-                if (validator.Conf.Tokens.VariableTypes.Mappings.TryGetValue(value, out DimensionType mappedType))
+                if (validator.Conf.Tokens.VariableTypes.Mappings.TryGetValue(value, out DimensionType _))
                 {
                     return null;
                 }
 
-                return CreateInvalidValueFeedback(entry, validator, ValidationFeedbackLevel.Error);
+                return CreateInvalidValueFeedback(entry, validator);
             }
             else if (keyword == validator.Conf.Tokens.KeyWords.ContentVariableIdentifier)
             {
@@ -361,25 +360,20 @@ namespace Px.Utils.Validation.ContentValidation
                     dimensionNames.AddRange(headingValues);
                 }
 
-                recommendedValueContents = [.. dimensionNames];
+                allowedValueContents = [.. dimensionNames];
             }
 
-            if (recommendedValueContents.Length > 0 && !recommendedValueContents.Contains(value, comparer))
+            if (allowedValueContents.Length == 0 || allowedValueContents.Contains(value, comparer))
             {
-                ValidationFeedbackLevel level = knownAliases.Contains(value, comparer)
-                    ? ValidationFeedbackLevel.Warning
-                    : ValidationFeedbackLevel.Error;
-
-                return CreateInvalidValueFeedback(entry, validator, level);
+                return null;
             }
 
-            return null;
+            return CreateInvalidValueFeedback(entry, validator);
         }
 
         private static ValidationFeedback CreateInvalidValueFeedback(
             ValidationStructuredEntry entry,
-            ContentValidator validator,
-            ValidationFeedbackLevel level)
+            ContentValidator validator)
         {
             KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
                 entry.KeyStartLineIndex,
@@ -387,7 +381,7 @@ namespace Px.Utils.Validation.ContentValidation
                 entry.LineChangeIndexes);
 
             KeyValuePair<ValidationFeedbackKey, ValidationFeedbackValue> feedback = new(
-                new(level,
+                new(ValidationFeedbackLevel.Error,
                     ValidationFeedbackRule.InvalidValueFound),
                 new(validator._filename,
                     feedbackIndexes.Key,

--- a/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
+++ b/Px.Utils/Validation/ContentValidation/ContentValidator.ValidationEntryFunctions.cs
@@ -1,3 +1,4 @@
+using Px.Utils.PxFile;
 using Px.Utils.Validation.SyntaxValidation;
 using System.Globalization;
 
@@ -322,31 +323,19 @@ namespace Px.Utils.Validation.ContentValidation
         {
             string[] allowedCharsets = ["ANSI", "Unicode"];
 
-            string[] dimensionTypes = [
-                validator.Conf.Tokens.VariableTypes.Content,
-                validator.Conf.Tokens.VariableTypes.Time,
-                validator.Conf.Tokens.VariableTypes.Geographical,
-                validator.Conf.Tokens.VariableTypes.Ordinal,
-                validator.Conf.Tokens.VariableTypes.Nominal,
-                validator.Conf.Tokens.VariableTypes.Other,
-                validator.Conf.Tokens.VariableTypes.Unknown,
-                validator.Conf.Tokens.VariableTypes.Classificatory
-            ];
-
-            string[] knownDimensionTypeAliases = [
-                validator.Conf.Tokens.VariableTypes.Contents,
-                validator.Conf.Tokens.VariableTypes.Region,
-            ];
+            HashSet<string> primaryDimensionTypes = GetPrimaryDimensionTypeTokens(validator.Conf);
+            HashSet<string> aliasDimensionTypes = GetAliasDimensionTypeTokens(validator.Conf);
 
             string value = SyntaxValidationUtilityMethods.CleanString(entry.Value, validator.Conf);
             if ((entry.Key.Keyword == validator.Conf.Tokens.KeyWords.Charset && !allowedCharsets.Contains(value)) ||
                 (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.CodePage && !value.Equals(validator._encoding.BodyName, StringComparison.OrdinalIgnoreCase)) ||
-                (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && !dimensionTypes.Contains(value)))
+                (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && !primaryDimensionTypes.Contains(value) && !aliasDimensionTypes.Contains(value)) ||
+                (entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && aliasDimensionTypes.Contains(value)))
             {
-                // If the value is included in known aliases, set level to warning instead of error
-                ValidationFeedbackLevel level = entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && knownDimensionTypeAliases.Contains(value) ?
-                        ValidationFeedbackLevel.Warning : 
-                        ValidationFeedbackLevel.Error;
+                // Using a known alias dimension type as a value for DimensionType is not invalid but is not recommended, so it is reported as a warning instead of an error
+                ValidationFeedbackLevel level = entry.Key.Keyword == validator.Conf.Tokens.KeyWords.DimensionType && aliasDimensionTypes.Contains(value)
+                    ? ValidationFeedbackLevel.Warning
+                    : ValidationFeedbackLevel.Error;
 
                 KeyValuePair<int, int> feedbackIndexes = SyntaxValidationUtilityMethods.GetLineAndCharacterIndex(
                     entry.KeyStartLineIndex,
@@ -472,6 +461,41 @@ namespace Px.Utils.Validation.ContentValidation
                 return new(feedback);
             }
             return null;
+        }
+
+        private static HashSet<string> GetPrimaryDimensionTypeTokens(PxFileConfiguration conf)
+        {
+            IEnumerable<string> primaryTokens = GetDimensionTypeTokenSets(conf)
+                .Select(tokens => tokens.FirstOrDefault())
+                .Where(token => !string.IsNullOrWhiteSpace(token))
+                .Cast<string>();
+
+            return [.. primaryTokens];
+        }
+
+        private static HashSet<string> GetAliasDimensionTypeTokens(PxFileConfiguration conf)
+        {
+            IEnumerable<string> aliasTokens = GetDimensionTypeTokenSets(conf)
+                .Where(tokens => tokens.Length > 1)
+                .SelectMany(tokens => tokens.Skip(1))
+                .Where(token => !string.IsNullOrWhiteSpace(token));
+
+            return [.. aliasTokens];
+        }
+
+        private static IEnumerable<string[]> GetDimensionTypeTokenSets(PxFileConfiguration conf)
+        {
+            return
+            [
+                conf.Tokens.VariableTypes.Content,
+                conf.Tokens.VariableTypes.Time,
+                conf.Tokens.VariableTypes.Ordinal,
+                conf.Tokens.VariableTypes.Nominal,
+                conf.Tokens.VariableTypes.Geographical,
+                conf.Tokens.VariableTypes.Other,
+                conf.Tokens.VariableTypes.Unknown,
+                conf.Tokens.VariableTypes.Classificatory
+            ];
         }
     }
 }

--- a/docs/PXFILE_SPECIFICATION.md
+++ b/docs/PXFILE_SPECIFICATION.md
@@ -96,7 +96,7 @@ Whitespace characters are not significant in the value outside of ```"``` separa
 - Decimal separator is period ```.```.
 - Thousands separator is not allowed.
 - Whitespace characters are not allowed between the characters of the number.
-- Number must be in range of ±7.9228 x 10^28.
+- Number must be in range of Â±7.9228 x 10^28.
 
 #### List of strings
 - List items are separated by a comma ```,```.
@@ -281,6 +281,7 @@ More spesific encoding information. The value must be a string that matches the 
 - Recommended that the variable type is defined for each variable defined by the STUB or HEADING.
 - Has a set of allowed values: ```Content```, ```Time```, ```Geographical```, ```Ordinal```, ```Nominal```, ```Other```, ```Classificatory```., ```Unknown```.
 - Can be defined for each language, but this is not recommended.
+- Value is not case sensitive, but uppercase characters are recommended.
 
 #### TIMEVAL
 - See the TIMEVAL entry for the syntax and content requirements.

--- a/docs/architecture.models.md
+++ b/docs/architecture.models.md
@@ -62,7 +62,7 @@ Task<MatrixMetadata> BuildAsync(IAsyncEnumerable<KeyValuePair<string, string>> m
 
 Helpers: `MetadataEntryKeyBuilder`, `ValueParserUtilities`, `MetadataEntryKey`.
 
-`PxFileConfiguration.TokenDefinitions.VariableTypeTokens` exposes configurable string arrays for each dimension type. The first value is the primary token used by builders, and any additional values are treated as aliases during parsing.
+`PxFileConfiguration.TokenDefinitions.VariableTypeTokens` exposes configurable string arrays for each dimension type. The first value is the primary recommended token for validation and parsing, and any additional values are treated as aliases during parsing.
 
 ## Extension Methods
 

--- a/docs/architecture.models.md
+++ b/docs/architecture.models.md
@@ -62,6 +62,8 @@ Task<MatrixMetadata> BuildAsync(IAsyncEnumerable<KeyValuePair<string, string>> m
 
 Helpers: `MetadataEntryKeyBuilder`, `ValueParserUtilities`, `MetadataEntryKey`.
 
+`PxFileConfiguration.TokenDefinitions.VariableTypeTokens` exposes configurable string arrays for each dimension type. The first value is the primary token used by builders, and any additional values are treated as aliases during parsing.
+
 ## Extension Methods
 
 | File | Purpose |

--- a/docs/architecture.models.md
+++ b/docs/architecture.models.md
@@ -62,7 +62,7 @@ Task<MatrixMetadata> BuildAsync(IAsyncEnumerable<KeyValuePair<string, string>> m
 
 Helpers: `MetadataEntryKeyBuilder`, `ValueParserUtilities`, `MetadataEntryKey`.
 
-`PxFileConfiguration.TokenDefinitions.VariableTypeTokens` exposes configurable string arrays for each dimension type. The first value is the primary recommended token for validation and parsing, and any additional values are treated as aliases during parsing.
+`PxFileConfiguration.TokenDefinitions.VariableTypeTokens` exposes a configurable `Dictionary<string, DimensionType>` (`Mappings`) used by both parsing and validation for `VARIABLE-TYPE` values. The dictionary uses `StringComparer.OrdinalIgnoreCase`, so lookups are case-insensitive by default. Custom aliases can be added by inserting additional keys into `Mappings`.
 
 ## Extension Methods
 

--- a/docs/architecture.overview.md
+++ b/docs/architecture.overview.md
@@ -27,6 +27,7 @@ No DI container — all types instantiated directly via constructors. Configurat
 | `Symbols.KeywordSeparator` | Keyword = value separator | `=` |
 | `Symbols.EntrySeparator` | Entry separator | `;` |
 | `Tokens.KeyWords.Data` | Data section keyword | `DATA` |
+| `Tokens.VariableTypes.Mappings` | `VARIABLE-TYPE` token to `DimensionType` mapping | Case-insensitive dictionary (`StringComparer.OrdinalIgnoreCase`) |
 
 ## Key Patterns
 

--- a/docs/architecture.validation.md
+++ b/docs/architecture.validation.md
@@ -34,6 +34,8 @@ Validates metadata content (required keys, language definitions, dimension consi
 File: `Validation/ContentValidation/ContentValidator.cs`  
 Partial files: `ValidationEntryFunctions.cs`, `ValidationFindKeywordFunctions.cs`, `UtilityMethods.cs`
 
+Dimension type validation uses `PxFileConfiguration.TokenDefinitions.VariableTypeTokens`. The first configured token for each dimension type is treated as the recommended primary value, while additional configured tokens are accepted as aliases and reported as warnings.
+
 ### DataValidator
 
 Validates data section (row counts, row lengths, value types, separators).  


### PR DESCRIPTION
Fixes a false positive validation issue when dimension types are defined by known aliases (Content/Contents and Geographical/Region). Added tests to cover the case.